### PR TITLE
refactor: no keywords, simpler lambda management

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -4,7 +4,6 @@ export const RPAREN = ")";
 export const TRUE = "true";
 export const FALSE = "false";
 export const NIL = "nil";
-export const KEYWORD_PREFIX = ":";
 export const STRING_DELIMITER = '"';
 
 // Special forms

--- a/lib/environment.test.ts
+++ b/lib/environment.test.ts
@@ -2,21 +2,21 @@ import { expect, test } from "bun:test";
 import { n } from "../tests/utils.js";
 import { Environment } from "./environment.js";
 import { std } from "./std/index.ts";
-import { ASTNodeType } from "./types.js";
+import { NodeType } from "./types.js";
 
 test("allows same-scope overrides", () => {
-  const num = n(ASTNodeType.NUMBER, 12);
+  const num = n(NodeType.NUMBER, 12);
   const env = new Environment();
-  env.set("a", n(ASTNodeType.NUMBER, 23));
+  env.set("a", n(NodeType.NUMBER, 23));
   env.set("a", num);
 
   expect(env.get("a")).toEqual(num);
 });
 
 test("shadows upper scopes", () => {
-  const num = n(ASTNodeType.NUMBER, 12);
+  const num = n(NodeType.NUMBER, 12);
   const parent = new Environment();
-  parent.set("a", n(ASTNodeType.NUMBER, 34));
+  parent.set("a", n(NodeType.NUMBER, 34));
   const child = new Environment(parent);
   child.set("a", num);
 
@@ -24,7 +24,7 @@ test("shadows upper scopes", () => {
 });
 
 test("shadows std", () => {
-  const num = n(ASTNodeType.NUMBER, 12);
+  const num = n(NodeType.NUMBER, 12);
   const env = new Environment();
   env.set("+", num);
 
@@ -32,7 +32,7 @@ test("shadows std", () => {
 });
 
 test("looks for variables in current scope", () => {
-  const num = n(ASTNodeType.NUMBER, 12);
+  const num = n(NodeType.NUMBER, 12);
   const env = new Environment();
   env.set("a", num);
 
@@ -40,7 +40,7 @@ test("looks for variables in current scope", () => {
 });
 
 test("looks for variables in upper scopes", () => {
-  const num = n(ASTNodeType.NUMBER, 12);
+  const num = n(NodeType.NUMBER, 12);
   const parent = new Environment();
   const child = new Environment(parent);
   parent.set("a", num);

--- a/lib/environment.ts
+++ b/lib/environment.ts
@@ -1,27 +1,22 @@
 import { SymbolNotFoundException } from "./errors.js";
 import { std } from "./std/index.js";
-import { ASTNodeType, type Expression } from "./types.js";
+import type { Value } from "./types.js";
 
 export class Environment {
   constructor(private parent: Environment = null) {}
 
   private readonly std = std;
-  private locals: Map<string, Expression> = new Map();
+  private locals: Map<string, Value> = new Map();
 
-  private getFromStandardLibrary(name: string): Expression | undefined {
-    return this.std[name] != null
-      ? {
-          type: ASTNodeType.FUNCTION,
-          value: this.std[name],
-        }
-      : null;
+  private getFromStandardLibrary(name: string): Value | undefined {
+    return this.std[name] ?? null;
   }
 
-  set(name: string, fn: Expression) {
+  set(name: string, fn: Value) {
     this.locals.set(name, fn);
   }
 
-  get(name: string): Expression {
+  get(name: string): Value {
     const expression =
       this.locals.get(name) ??
       this.parent?.get(name) ??

--- a/lib/evaluate.test.ts
+++ b/lib/evaluate.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, mock } from "bun:test";
 import { evaluate } from "./evaluate.js";
-import { ASTNodeType, type Expression } from "./types.js";
+import { Lambda, NodeType, type Value } from "./types.js";
 import { n, l } from "../tests/utils.js";
 import { Environment } from "./environment.js";
 import { FN } from "./constants.ts";
@@ -8,59 +8,47 @@ import type { specials } from "./specials.ts";
 
 test("number literal", () => {
   const env = new Environment();
-  expect(evaluate(n(ASTNodeType.NUMBER, 42), env)).toEqual(
-    n(ASTNodeType.NUMBER, 42),
-  );
+  expect(evaluate(n(NodeType.NUMBER, 42), env)).toEqual(42);
 });
 
 test("string literal", () => {
   const env = new Environment();
-  expect(evaluate(n(ASTNodeType.STRING, "hi"), env)).toEqual(
-    n(ASTNodeType.STRING, "hi"),
-  );
+  expect(evaluate(n(NodeType.STRING, "hi"), env)).toEqual("hi");
 });
 
 test("boolean literal", () => {
   const env = new Environment();
-  expect(evaluate(n(ASTNodeType.BOOLEAN, true), env)).toEqual(
-    n(ASTNodeType.BOOLEAN, true),
-  );
+  expect(evaluate(n(NodeType.BOOLEAN, true), env)).toEqual(true);
 });
 
 test("nil literal", () => {
   const env = new Environment();
-  expect(evaluate(n(ASTNodeType.NIL, null), env)).toEqual(
-    n(ASTNodeType.NIL, null),
-  );
+  expect(evaluate(n(NodeType.NIL, null), env)).toBeNull();
 });
 
 test("resolved symbols", () => {
   const env = new Environment();
-  env.set("foo", n(ASTNodeType.NUMBER, 99));
-  expect(evaluate(n(ASTNodeType.SYMBOL, "foo"), env)).toEqual(
-    n(ASTNodeType.NUMBER, 99),
-  );
+  env.set("foo", 99);
+  expect(evaluate(n(NodeType.SYMBOL, "foo"), env)).toEqual(99);
 });
 
 test("throws when symbol is not found", () => {
   const env = new Environment();
-  expect(() => evaluate(n(ASTNodeType.SYMBOL, "bar"), env)).toThrow();
+  expect(() => evaluate(n(NodeType.SYMBOL, "bar"), env)).toThrow();
 });
 
 test("resolved lambdas", () => {
-  // @ts-expect-error sloppy types for test purposes
-  const fn = (nodes: Expression[]) => n(ASTNodeType.NUMBER, nodes[0].value + 1);
+  const fn: Lambda = ([value]) => (value as number) + 1;
   const env = new Environment();
-  env.set("inc", { type: ASTNodeType.FUNCTION, value: fn });
-  const tree = l([n(ASTNodeType.SYMBOL, "inc"), n(ASTNodeType.NUMBER, 2)]);
-
-  expect(evaluate(tree, env)).toEqual(n(ASTNodeType.NUMBER, 3));
+  env.set("inc", fn);
+  const tree = l([n(NodeType.SYMBOL, "inc"), n(NodeType.NUMBER, 2)]);
+  expect(evaluate(tree, env)).toEqual(3);
 });
 
 test("call special forms", () => {
   const specs = { [FN]: mock() } as unknown as typeof specials;
   const env = new Environment();
-  const tree = l([n(ASTNodeType.SYMBOL, FN), n(ASTNodeType.NUMBER, 1)]);
+  const tree = l([n(NodeType.SYMBOL, FN), n(NodeType.NUMBER, 1)]);
   evaluate(tree, env, specs);
   expect(specs[FN]).toBeCalled();
 });
@@ -68,13 +56,11 @@ test("call special forms", () => {
 test("empty list returns itself", () => {
   const env = new Environment();
   const tree = l([]);
-  expect(evaluate(tree, env)).toEqual(tree);
+  expect(evaluate(tree, env)).toEqual([]);
 });
 
 test("fallback list evaluation", () => {
   const env = new Environment();
-  const tree = l([n(ASTNodeType.NUMBER, 1), n(ASTNodeType.NUMBER, 2)]);
-  expect(evaluate(tree, env)).toEqual(
-    l([n(ASTNodeType.NUMBER, 1), n(ASTNodeType.NUMBER, 2)]),
-  );
+  const tree = l([n(NodeType.NUMBER, 1), n(NodeType.NUMBER, 2)]);
+  expect(evaluate(tree, env)).toEqual([1, 2]);
 });

--- a/lib/evaluate.test.ts
+++ b/lib/evaluate.test.ts
@@ -4,7 +4,7 @@ import { ASTNodeType, type Expression } from "./types.js";
 import { n, l } from "../tests/utils.js";
 import { Environment } from "./environment.js";
 import { FN } from "./constants.ts";
-import { specials } from "./specials.ts";
+import type { specials } from "./specials.ts";
 
 test("number literal", () => {
   const env = new Environment();

--- a/lib/print.test.ts
+++ b/lib/print.test.ts
@@ -9,7 +9,6 @@ test("atoms", () => {
     [n(ASTNodeType.NUMBER, 1), "1"],
     [n(ASTNodeType.SYMBOL, "asd"), "asd"],
     [n(ASTNodeType.STRING, "asd"), '"asd"'],
-    [n(ASTNodeType.KEYWORD, ":asd"), ":asd"],
     [n(ASTNodeType.BOOLEAN, true), "true"],
   ];
 
@@ -26,9 +25,9 @@ test("lists", () => {
         n(ASTNodeType.NIL, null),
         n(ASTNodeType.NUMBER, 1),
         n(ASTNodeType.BOOLEAN, true),
-        n(ASTNodeType.KEYWORD, ":lol"),
+        n(ASTNodeType.SYMBOL, "lol"),
       ]),
-      "(nil 1 true :lol)",
+      "(nil 1 true lol)",
     ],
     [l([n(ASTNodeType.NIL, null), l([n(ASTNodeType.NUMBER, 1)])]), "(nil (1))"],
   ];

--- a/lib/print.test.ts
+++ b/lib/print.test.ts
@@ -1,15 +1,14 @@
 import { expect, test } from "bun:test";
-import { l, n } from "../tests/utils.js";
 import { print } from "./print.js";
-import { ASTNodeType, type Expression } from "./types.js";
+import { type Value } from "./types.js";
 
 test("atoms", () => {
-  const tests: [Expression, string][] = [
-    [n(ASTNodeType.NIL, null), "nil"],
-    [n(ASTNodeType.NUMBER, 1), "1"],
-    [n(ASTNodeType.SYMBOL, "asd"), "asd"],
-    [n(ASTNodeType.STRING, "asd"), '"asd"'],
-    [n(ASTNodeType.BOOLEAN, true), "true"],
+  const tests: [Value, string][] = [
+    [null, "nil"],
+    [1, "1"],
+    ["asd", '"asd"'],
+    [true, "true"],
+    [() => null, "#<function>"],
   ];
 
   for (const [input, expected] of tests) {
@@ -18,18 +17,10 @@ test("atoms", () => {
 });
 
 test("lists", () => {
-  const tests: [Expression, string][] = [
-    [l([n(ASTNodeType.NIL, null)]), "(nil)"],
-    [
-      l([
-        n(ASTNodeType.NIL, null),
-        n(ASTNodeType.NUMBER, 1),
-        n(ASTNodeType.BOOLEAN, true),
-        n(ASTNodeType.SYMBOL, "lol"),
-      ]),
-      "(nil 1 true lol)",
-    ],
-    [l([n(ASTNodeType.NIL, null), l([n(ASTNodeType.NUMBER, 1)])]), "(nil (1))"],
+  const tests: [Value, string][] = [
+    [[null], "(nil)"],
+    [[null, 1, true, "lol"], '(nil 1 true "lol")'],
+    [[null, [1]], "(nil (1))"],
   ];
 
   for (const [input, expected] of tests) {

--- a/lib/print.ts
+++ b/lib/print.ts
@@ -7,7 +7,6 @@ export const print = (expression: Expression): string => {
       return `${STRING_DELIMITER}${expression.value}${STRING_DELIMITER}`;
     case ASTNodeType.SYMBOL:
     case ASTNodeType.NUMBER:
-    case ASTNodeType.KEYWORD:
       return `${expression.value}`;
     case ASTNodeType.NIL:
       return NIL;

--- a/lib/print.ts
+++ b/lib/print.ts
@@ -1,20 +1,22 @@
 import { FALSE, NIL, STRING_DELIMITER, TRUE } from "./constants.js";
-import { type Expression, ASTNodeType } from "./types.js";
+import { isList, isNull, type Value } from "./types.js";
 
-export const print = (expression: Expression): string => {
-  switch (expression.type) {
-    case ASTNodeType.STRING:
-      return `${STRING_DELIMITER}${expression.value}${STRING_DELIMITER}`;
-    case ASTNodeType.SYMBOL:
-    case ASTNodeType.NUMBER:
-      return `${expression.value}`;
-    case ASTNodeType.NIL:
-      return NIL;
-    case ASTNodeType.BOOLEAN:
-      return expression.value ? TRUE : FALSE;
-    case ASTNodeType.FUNCTION:
+export const print = (value: Value): string => {
+  switch (typeof value) {
+    case "string":
+      return `${STRING_DELIMITER}${value}${STRING_DELIMITER}`;
+    case "number":
+      return `${value}`;
+    case "boolean":
+      return value ? TRUE : FALSE;
+    case "function":
       return `#<function>`;
-    case ASTNodeType.LIST:
-      return `(${expression.value.map((i) => print(i)).join(" ")})`;
+    case "object": {
+      if (isNull(value)) {
+        return NIL;
+      } else if (isList(value)) {
+        return `(${value.map((i) => print(i)).join(" ")})`;
+      }
+    }
   }
 };

--- a/lib/read.test.ts
+++ b/lib/read.test.ts
@@ -1,16 +1,16 @@
 import { expect, test } from "bun:test";
 import { l, n } from "../tests/utils.js";
 import { read } from "./read.js";
-import { type ASTNode, ASTNodeType } from "./types.js";
+import { type Node, NodeType } from "./types.js";
 
 test("reads atoms", () => {
-  const tests: [string, ASTNode][] = [
-    ["1", n(ASTNodeType.NUMBER, 1)],
-    ["true", n(ASTNodeType.BOOLEAN, true)],
-    ["false", n(ASTNodeType.BOOLEAN, false)],
-    ['"lol"', n(ASTNodeType.STRING, "lol")],
-    ["add-one", n(ASTNodeType.SYMBOL, "add-one")],
-    ["nil", n(ASTNodeType.NIL, null)],
+  const tests: [string, Node][] = [
+    ["1", n(NodeType.NUMBER, 1)],
+    ["true", n(NodeType.BOOLEAN, true)],
+    ["false", n(NodeType.BOOLEAN, false)],
+    ['"lol"', n(NodeType.STRING, "lol")],
+    ["add-one", n(NodeType.SYMBOL, "add-one")],
+    ["nil", n(NodeType.NIL, null)],
   ];
 
   for (const [input, expected] of tests) {
@@ -19,11 +19,11 @@ test("reads atoms", () => {
 });
 
 test("reads unary lists", () => {
-  const tests: [string, ASTNode][] = [
-    ["(1)", l([n(ASTNodeType.NUMBER, 1)])],
-    ["(true)", l([n(ASTNodeType.BOOLEAN, true)])],
-    ['("true")', l([n(ASTNodeType.STRING, "true")])],
-    ["(nil)", l([n(ASTNodeType.NIL, null)])],
+  const tests: [string, Node][] = [
+    ["(1)", l([n(NodeType.NUMBER, 1)])],
+    ["(true)", l([n(NodeType.BOOLEAN, true)])],
+    ['("true")', l([n(NodeType.STRING, "true")])],
+    ["(nil)", l([n(NodeType.NIL, null)])],
   ];
 
   for (const [input, expected] of tests) {
@@ -32,50 +32,50 @@ test("reads unary lists", () => {
 });
 
 test("reads empty list", () => {
-  expect(read("()")).toEqual(n(ASTNodeType.LIST, []));
+  expect(read("()")).toEqual(n(NodeType.LIST, []));
 });
 
 test("reads complex lists", () => {
-  const tests: [string, ASTNode][] = [
+  const tests: [string, Node][] = [
     [
       "(add 1 2)",
       l([
-        n(ASTNodeType.SYMBOL, "add"),
-        n(ASTNodeType.NUMBER, 1),
-        n(ASTNodeType.NUMBER, 2),
+        n(NodeType.SYMBOL, "add"),
+        n(NodeType.NUMBER, 1),
+        n(NodeType.NUMBER, 2),
       ]),
     ],
     [
       "(def! a 2)",
       l([
-        n(ASTNodeType.SYMBOL, "def!"),
-        n(ASTNodeType.SYMBOL, "a"),
-        n(ASTNodeType.NUMBER, 2),
+        n(NodeType.SYMBOL, "def!"),
+        n(NodeType.SYMBOL, "a"),
+        n(NodeType.NUMBER, 2),
       ]),
     ],
     [
       '(concat "hel" ("l" "o"))',
       l([
-        n(ASTNodeType.SYMBOL, "concat"),
-        n(ASTNodeType.STRING, "hel"),
-        l([n(ASTNodeType.STRING, "l"), n(ASTNodeType.STRING, "o")]),
+        n(NodeType.SYMBOL, "concat"),
+        n(NodeType.STRING, "hel"),
+        l([n(NodeType.STRING, "l"), n(NodeType.STRING, "o")]),
       ]),
     ],
     [
       '(key 1 (nil "l"))',
       l([
-        n(ASTNodeType.SYMBOL, "key"),
-        n(ASTNodeType.NUMBER, 1),
-        l([n(ASTNodeType.NIL, null), n(ASTNodeType.STRING, "l")]),
+        n(NodeType.SYMBOL, "key"),
+        n(NodeType.NUMBER, 1),
+        l([n(NodeType.NIL, null), n(NodeType.STRING, "l")]),
       ]),
     ],
     [
       "(add 1 (1 2) (3 (4)))",
       l([
-        n(ASTNodeType.SYMBOL, "add"),
-        n(ASTNodeType.NUMBER, 1),
-        l([n(ASTNodeType.NUMBER, 1), n(ASTNodeType.NUMBER, 2)]),
-        l([n(ASTNodeType.NUMBER, 3), l([n(ASTNodeType.NUMBER, 4)])]),
+        n(NodeType.SYMBOL, "add"),
+        n(NodeType.NUMBER, 1),
+        l([n(NodeType.NUMBER, 1), n(NodeType.NUMBER, 2)]),
+        l([n(NodeType.NUMBER, 3), l([n(NodeType.NUMBER, 4)])]),
       ]),
     ],
   ];

--- a/lib/read.test.ts
+++ b/lib/read.test.ts
@@ -9,7 +9,6 @@ test("reads atoms", () => {
     ["true", n(ASTNodeType.BOOLEAN, true)],
     ["false", n(ASTNodeType.BOOLEAN, false)],
     ['"lol"', n(ASTNodeType.STRING, "lol")],
-    [":key", n(ASTNodeType.KEYWORD, ":key")],
     ["add-one", n(ASTNodeType.SYMBOL, "add-one")],
     ["nil", n(ASTNodeType.NIL, null)],
   ];
@@ -24,7 +23,6 @@ test("reads unary lists", () => {
     ["(1)", l([n(ASTNodeType.NUMBER, 1)])],
     ["(true)", l([n(ASTNodeType.BOOLEAN, true)])],
     ['("true")', l([n(ASTNodeType.STRING, "true")])],
-    ["(:key)", l([n(ASTNodeType.KEYWORD, ":key")])],
     ["(nil)", l([n(ASTNodeType.NIL, null)])],
   ];
 
@@ -64,9 +62,9 @@ test("reads complex lists", () => {
       ]),
     ],
     [
-      '(:key 1 (nil "l"))',
+      '(key 1 (nil "l"))',
       l([
-        n(ASTNodeType.KEYWORD, ":key"),
+        n(ASTNodeType.SYMBOL, "key"),
         n(ASTNodeType.NUMBER, 1),
         l([n(ASTNodeType.NIL, null), n(ASTNodeType.STRING, "l")]),
       ]),

--- a/lib/read.ts
+++ b/lib/read.ts
@@ -8,7 +8,6 @@ import {
   ASTNodeType,
   type AtomToken,
   isAtomToken,
-  isKeyword,
   type Token,
   TokenType,
 } from "./types.js";
@@ -20,9 +19,6 @@ const parseAtom = (token: AtomToken): ASTNode => {
     case TokenType.STRING:
       return { type: ASTNodeType.STRING, value: token.literal };
     case TokenType.SYMBOL: {
-      if (isKeyword(token.literal)) {
-        return { type: ASTNodeType.KEYWORD, value: token.literal };
-      }
       if ([TRUE, FALSE].includes(token.literal)) {
         return { type: ASTNodeType.BOOLEAN, value: token.literal === TRUE };
       }

--- a/lib/read.ts
+++ b/lib/read.ts
@@ -2,32 +2,31 @@ import { FALSE, NIL, TRUE } from "./constants.js";
 import { SyntaxException } from "./errors.js";
 import { tokenize } from "./lexer.js";
 import {
-  type AbstractSyntaxTree,
-  type ASTNode,
-  type ASTNodeList,
-  ASTNodeType,
   type AtomToken,
   isAtomToken,
+  type Node,
+  type NodeList,
+  NodeType,
   type Token,
   TokenType,
 } from "./types.js";
 
-const parseAtom = (token: AtomToken): ASTNode => {
+const parseAtom = (token: AtomToken): Node => {
   switch (token.type) {
     case TokenType.NUMBER:
-      return { type: ASTNodeType.NUMBER, value: token.literal };
+      return { type: NodeType.NUMBER, value: token.literal };
     case TokenType.STRING:
-      return { type: ASTNodeType.STRING, value: token.literal };
+      return { type: NodeType.STRING, value: token.literal };
     case TokenType.SYMBOL: {
       if ([TRUE, FALSE].includes(token.literal)) {
-        return { type: ASTNodeType.BOOLEAN, value: token.literal === TRUE };
+        return { type: NodeType.BOOLEAN, value: token.literal === TRUE };
       }
 
       if (token.literal === NIL) {
-        return { type: ASTNodeType.NIL, value: null };
+        return { type: NodeType.NIL, value: null };
       }
 
-      return { type: ASTNodeType.SYMBOL, value: token.literal };
+      return { type: NodeType.SYMBOL, value: token.literal };
     }
   }
 };
@@ -35,12 +34,12 @@ const parseAtom = (token: AtomToken): ASTNode => {
 const parseList = (
   tokens: Token[],
   reader: { depth: number; index: number },
-): ASTNodeList => {
+): NodeList => {
   if (tokens.length <= 1 || tokens[reader.index].type !== TokenType.LPAREN) {
     throw new SyntaxException("Invalid list");
   }
 
-  const result: ASTNodeList = { type: ASTNodeType.LIST, value: [] };
+  const result: NodeList = { type: NodeType.LIST, value: [] };
 
   reader.index++;
   reader.depth++;
@@ -62,10 +61,10 @@ const parseList = (
   return result;
 };
 
-export const read = (line: string): AbstractSyntaxTree => {
+export const read = (line: string): Node => {
   const tokens = tokenize(line);
 
-  if (tokens.length === 0) return { type: ASTNodeType.NIL, value: null };
+  if (tokens.length === 0) return { type: NodeType.NIL, value: null };
 
   const reader = { depth: 0, index: 0 };
   const first = tokens[0];

--- a/lib/std/io.test.ts
+++ b/lib/std/io.test.ts
@@ -1,7 +1,7 @@
 import { expect, spyOn, test } from "bun:test";
 import { n } from "../../tests/utils.js";
-import { io } from "./io.js";
 import { ASTNodeType } from "../types.js";
+import { io } from "./io.js";
 
 test("io.stdout", () => {
   const spy = spyOn(process.stdout, "write");

--- a/lib/std/io.test.ts
+++ b/lib/std/io.test.ts
@@ -1,64 +1,59 @@
 import { expect, spyOn, test } from "bun:test";
-import { n } from "../../tests/utils.js";
-import { ASTNodeType } from "../types.js";
 import { io } from "./io.js";
 
 test("io.stdout", () => {
   const spy = spyOn(process.stdout, "write");
   spy.mockImplementation(() => null);
-  const node = n(ASTNodeType.STRING, "hello");
-  const result = io["io.stdout"]([node]);
+  const value = "hello";
+  const result = io["io.stdout"]([value]);
   expect(spy).toBeCalledWith('"hello"');
-  expect(result).toEqual({ type: ASTNodeType.NIL, value: null });
+  expect(result).toBeNull();
   spy.mockRestore();
 });
 
 test("io.stderr", () => {
   const spy = spyOn(process.stderr, "write");
   spy.mockImplementation(() => null);
-  const node = n(ASTNodeType.STRING, "hello");
-  const result = io["io.stderr"]([node]);
+  const value = "hello";
+  const result = io["io.stderr"]([value]);
   expect(spy).toBeCalledWith('"hello"');
-  expect(result).toEqual({ type: ASTNodeType.NIL, value: null });
+  expect(result).toBeNull();
   spy.mockRestore();
 });
 
 test("io stream - errors", () => {
-  const node = n(ASTNodeType.STRING, "hello");
+  const value = "hello";
   expect(() => io["io.stdout"]([])).toThrow();
-  expect(() => io["io.stderr"]([node, node])).toThrow();
+  expect(() => io["io.stderr"]([value, value])).toThrow();
 });
 
 test("io.printf", () => {
   const spy = spyOn(process.stdout, "write");
   spy.mockImplementation(() => null);
-  const format = n(ASTNodeType.STRING, "hello %s %d");
-  const values = n(ASTNodeType.LIST, [
-    n(ASTNodeType.STRING, "world"),
-    n(ASTNodeType.NUMBER, 42),
-  ]);
+  const format = "hello %s %d";
+  const values = ["world", 42];
   const result = io["io.printf"]([format, values]);
   expect(spy).toBeCalledWith("hello world 42");
-  expect(result).toEqual({ type: ASTNodeType.NIL, value: null });
+  expect(result).toBeNull();
   spy.mockRestore();
 });
 
 test("io.printf - line breaks", () => {
   const spy = spyOn(process.stdout, "write");
   spy.mockImplementation(() => null);
-  const format = n(ASTNodeType.STRING, "hello %s\n");
-  const values = n(ASTNodeType.LIST, [n(ASTNodeType.STRING, "world")]);
+  const format = "hello %s\n";
+  const values = ["world"];
   const result = io["io.printf"]([format, values]);
   expect(spy, JSON.stringify(spy.mock.calls)).toBeCalledWith("hello world\n");
-  expect(result).toEqual({ type: ASTNodeType.NIL, value: null });
+  expect(result).toBeNull();
   spy.mockRestore();
 });
 
 test("printf - errors", () => {
-  const format = n(ASTNodeType.STRING, "hello %s");
-  const values = n(ASTNodeType.LIST, [n(ASTNodeType.STRING, "world")]);
+  const format = "hello %s";
+  const values = ["world"];
   expect(() => io["io.printf"]([])).toThrow();
   expect(() => io["io.printf"]([format])).toThrow();
   expect(() => io["io.printf"]([values, values])).toThrow();
-  expect(() => io["io.printf"]([format, n(ASTNodeType.NUMBER, 1)])).toThrow();
+  expect(() => io["io.printf"]([format, 1])).toThrow();
 });

--- a/lib/std/io.ts
+++ b/lib/std/io.ts
@@ -1,10 +1,10 @@
+import * as util from "node:util";
 import { InvalidArgumentException } from "../errors.js";
 import { print } from "../print.js";
-import { ASTNodeType, type Expression, type Lambda } from "../types.js";
-import * as util from "node:util";
+import { isList, isString, Lambda, Value } from "../types.js";
 
 const ioWriteFunction = (
-  nodes: Expression[],
+  nodes: Value[],
   name: string,
   stream: NodeJS.WriteStream,
 ) => {
@@ -14,7 +14,7 @@ const ioWriteFunction = (
     );
   }
   stream.write(print(nodes[0]));
-  return { type: ASTNodeType.NIL, value: null };
+  return null;
 };
 
 export const io: Record<string, Lambda> = {
@@ -43,19 +43,13 @@ export const io: Record<string, Lambda> = {
    *   (io.printf "hello %s %d" ("world" 42))
    */
   "io.printf": (nodes) => {
-    if (
-      nodes.length !== 2 ||
-      nodes[0].type !== ASTNodeType.STRING ||
-      nodes[1].type !== ASTNodeType.LIST
-    ) {
+    if (nodes.length !== 2 || !isString(nodes[0]) || !isList(nodes[1])) {
       throw new InvalidArgumentException(
-        `'io.printf' requires a format string, and a list of arguments. Example: (printf "hello %s" ("world"))`,
+        `'io.printf' requires a format string, and a list of arguments. Example: (io.printf "hello %s" ("world"))`,
       );
     }
     const [format, values] = nodes;
-    process.stdout.write(
-      util.format(format.value, ...values.value.map((i: any) => i.value)),
-    );
-    return { type: ASTNodeType.NIL, value: null };
+    process.stdout.write(util.format(format, ...values));
+    return null;
   },
 };

--- a/lib/std/lists.test.ts
+++ b/lib/std/lists.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { n, l } from "../../tests/utils.js";
 import { lists } from "./lists.js";
-import { ASTNodeList, ASTNodeType, Expression } from "../types.js";
+import { type ASTNodeList, ASTNodeType, type Expression } from "../types.js";
 
 test("list.count", () => {
   const listNode = l([n(ASTNodeType.NUMBER, 1), n(ASTNodeType.NUMBER, 2)]);

--- a/lib/std/lists.test.ts
+++ b/lib/std/lists.test.ts
@@ -1,78 +1,47 @@
 import { expect, test } from "bun:test";
-import { n, l } from "../../tests/utils.js";
 import { lists } from "./lists.js";
-import { type ASTNodeList, ASTNodeType, type Expression } from "../types.js";
+import { isList } from "../types.ts";
 
 test("list.count", () => {
-  const listNode = l([n(ASTNodeType.NUMBER, 1), n(ASTNodeType.NUMBER, 2)]);
-  expect(lists["list.count"]([listNode])).toEqual(n(ASTNodeType.NUMBER, 2));
-  expect(() => lists["list.count"]([n(ASTNodeType.NUMBER, 1)])).toThrow();
+  expect(lists["list.count"]([[1, 2]])).toBe(2);
+  expect(() => lists["list.count"]([1])).toThrow();
 });
 
 test("list.map", () => {
-  const fn = {
-    type: ASTNodeType.FUNCTION,
-    value: (([item, idx]: any[]) =>
-      n(ASTNodeType.NUMBER, item.value + idx.value)) as any,
-  };
-  const listNode = l([n(ASTNodeType.NUMBER, 1), n(ASTNodeType.NUMBER, 2)]);
-  const result = lists["list.map"]([fn, listNode]);
-  expect(result.type).toBe(ASTNodeType.LIST);
-  expect(result.value[0].value).toBe(1);
-  expect(result.value[1].value).toBe(3);
-  expect(() => lists["list.map"]([fn, n(ASTNodeType.NUMBER, 1)])).toThrow();
+  const fn = ([val, idx]: number[]) => val + idx;
+  const result = lists["list.map"]([fn, [1, 2]]);
+  expect(Array.isArray(result)).toBe(true);
+  expect(result[0]).toBe(1);
+  expect(result[1]).toBe(3);
+  expect(() => lists["list.map"]([fn, 1])).toThrow();
 });
 
 test("list.each", () => {
   let acc = 0;
-  const fn = {
-    type: ASTNodeType.FUNCTION,
-    value: (([item, idx]: any[]) => {
-      acc += item.value + idx.value;
-      return n(ASTNodeType.NIL, null);
-    }) as any,
+  const fn = ([val, idx]: number[]) => {
+    acc += val + idx;
+    return null;
   };
-  const listNode = l([n(ASTNodeType.NUMBER, 1), n(ASTNodeType.NUMBER, 2)]);
-  const result = lists["list.each"]([fn, listNode]);
-  expect(result).toEqual(n(ASTNodeType.NIL, null));
+  const result = lists["list.each"]([fn, [1, 2]]);
+  expect(result).toBeNull();
   expect(acc).toBe(1 + 0 + 2 + 1);
-  expect(() => lists["list.each"]([fn, n(ASTNodeType.NUMBER, 1)])).toThrow();
+  expect(() => lists["list.each"]([fn, 1])).toThrow();
 });
 
 test("list.nth", () => {
-  const listNode = l([
-    n(ASTNodeType.NUMBER, 1),
-    n(ASTNodeType.NUMBER, 2),
-    n(ASTNodeType.NUMBER, 3),
-  ]);
-  expect(lists["list.nth"]([n(ASTNodeType.NUMBER, 0), listNode])).toEqual(
-    n(ASTNodeType.NUMBER, 1),
-  );
-  expect(lists["list.nth"]([n(ASTNodeType.NUMBER, 2), listNode])).toEqual(
-    n(ASTNodeType.NUMBER, 3),
-  );
-  expect(lists["list.nth"]([n(ASTNodeType.NUMBER, 10), listNode])).toEqual(
-    n(ASTNodeType.NIL, null),
-  );
-  expect(() =>
-    lists["list.nth"]([n(ASTNodeType.NUMBER, 0), n(ASTNodeType.NUMBER, 1)]),
-  ).toThrow();
+  const arr = [1, 2, 3];
+  expect(lists["list.nth"]([0, arr])).toBe(1);
+  expect(lists["list.nth"]([2, arr])).toBe(3);
+  expect(lists["list.nth"]([10, arr])).toBeNull();
+  expect(() => lists["list.nth"]([0, 1])).toThrow();
 });
 
 test("list.filter", () => {
-  const fn: Expression = {
-    type: ASTNodeType.FUNCTION,
-    value: ([item]) => n(ASTNodeType.BOOLEAN, (item.value as number) % 2 === 1),
-  };
-  const listNode = l([
-    n(ASTNodeType.NUMBER, 1),
-    n(ASTNodeType.NUMBER, 2),
-    n(ASTNodeType.NUMBER, 3),
-  ]);
-  const result = lists["list.filter"]([fn, listNode]) as ASTNodeList;
-  expect(result.type).toBe(ASTNodeType.LIST);
-  expect(result.value.length).toBe(2);
-  expect(result.value[0].value).toBe(1);
-  expect(result.value[1].value).toBe(3);
-  expect(() => lists["list.filter"]([fn, n(ASTNodeType.NUMBER, 1)])).toThrow();
+  const fn = ([val, _]: number[]) => val % 2 === 1;
+  const arr = [1, 2, 3];
+  const result = lists["list.filter"]([fn, arr]);
+  expect(isList(result)).toBe(true);
+  expect(result[0]).toBe(1);
+  expect(result[1]).toBe(3);
+  expect(() => lists["list.filter"]([fn, 1])).toThrow();
 });

--- a/lib/std/lists.ts
+++ b/lib/std/lists.ts
@@ -1,5 +1,6 @@
 import { InvalidArgumentException } from "../errors.js";
-import { type ASTNodeList, ASTNodeType, type Lambda } from "../types.js";
+import type { Value } from "../types.js";
+import { isLambda, isList, isNumber, type Lambda } from "../types.js";
 
 export const lists: Record<string, Lambda> = {
   /**
@@ -9,15 +10,12 @@ export const lists: Record<string, Lambda> = {
    *   (list.count (1 2)) ; 2
    */
   "list.count": (nodes) => {
-    if (nodes.length !== 1 || nodes[0].type !== ASTNodeType.LIST) {
+    if (nodes.length !== 1 || !isList(nodes[0])) {
       throw new InvalidArgumentException(
         "'list.count' takes a list as argument. Example: (list.count my-list).",
       );
     }
-    return {
-      type: ASTNodeType.NUMBER,
-      value: nodes[0].value.length,
-    };
+    return nodes[0].length;
   },
   /**
    * Maps a lambda over a list.
@@ -26,22 +24,13 @@ export const lists: Record<string, Lambda> = {
    *   (list.map (fn* (item idx) (+ item idx)) (1 2 3)) ; (1 3 5)
    */
   "list.map": (nodes) => {
-    if (
-      nodes.length !== 2 ||
-      nodes[1].type !== ASTNodeType.LIST ||
-      nodes[0].type !== ASTNodeType.FUNCTION
-    ) {
+    if (nodes.length !== 2 || !isLambda(nodes[0]) || !isList(nodes[1])) {
       throw new InvalidArgumentException(
         "'list.map' takes a lambda and a list as argument. Example: (list.map (fn* (item idx) (myfn item idx)) my-list).",
       );
     }
     const [lambda, list] = nodes;
-    return {
-      type: ASTNodeType.LIST,
-      value: list.value.map((node: ASTNodeList, value: number) =>
-        lambda.value([node, { type: ASTNodeType.NUMBER, value }]),
-      ),
-    };
+    return list.map((value, idx) => lambda([value, idx]));
   },
   /**
    * Applies a lambda to each element in a list (for side effects).
@@ -50,23 +39,14 @@ export const lists: Record<string, Lambda> = {
    *   (list.each (fn* (item idx) (print item)) (1 2 3)) ; nil
    */
   "list.each": (nodes) => {
-    if (
-      nodes.length !== 2 ||
-      nodes[1].type !== ASTNodeType.LIST ||
-      nodes[0].type !== ASTNodeType.FUNCTION
-    ) {
+    if (nodes.length !== 2 || !isLambda(nodes[0]) || !isList(nodes[1])) {
       throw new InvalidArgumentException(
         "'list.each' takes a lambda and a list as argument. Example: (list.each (fn* (item idx) (myfn item idx)) my-list).",
       );
     }
     const [lambda, list] = nodes;
-    list.value.forEach((node: ASTNodeList, value) =>
-      lambda.value([node, { type: ASTNodeType.NUMBER, value }]),
-    );
-    return {
-      type: ASTNodeType.NIL,
-      value: null,
-    };
+    list.forEach((value, idx) => lambda([value, idx]));
+    return null;
   },
   /**
    * Creates a list from the given arguments.
@@ -74,10 +54,7 @@ export const lists: Record<string, Lambda> = {
    * @example
    *   (list.from 1 2 3) ; (1 2 3)
    */
-  "list.from": (nodes) => ({
-    type: ASTNodeType.LIST,
-    value: nodes,
-  }),
+  "list.from": (nodes: Value[]) => nodes,
   /**
    * Returns the nth element of a list, or nil if out of bounds.
    * @name list.nth
@@ -85,25 +62,14 @@ export const lists: Record<string, Lambda> = {
    *   (list.nth 1 (10 20 30)) ; 20
    */
   "list.nth": (nodes) => {
-    if (
-      nodes.length !== 2 ||
-      nodes[0].type !== ASTNodeType.NUMBER ||
-      nodes[1].type !== ASTNodeType.LIST
-    ) {
+    if (nodes.length !== 2 || !isNumber(nodes[0]) || !isList(nodes[1])) {
       throw new InvalidArgumentException(
         "'list.nth' takes a number and a list as argument. Example: (list.nth 0 my-list).",
       );
     }
 
     const [index, list] = nodes;
-    const item = list.value[index.value];
-
-    return (
-      item ?? {
-        type: ASTNodeType.NIL,
-        value: null,
-      }
-    );
+    return list[index] ?? null;
   },
   /**
    * Filters a list using a lambda predicate.
@@ -112,22 +78,12 @@ export const lists: Record<string, Lambda> = {
    *   (list.filter (fn* (item idx) (> item 0)) (-1 0 1 2)) ; (1 2)
    */
   "list.filter": (nodes) => {
-    if (
-      nodes.length !== 2 ||
-      nodes[1].type !== ASTNodeType.LIST ||
-      nodes[0].type !== ASTNodeType.FUNCTION
-    ) {
+    if (nodes.length !== 2 || !isLambda(nodes[0]) || !isList(nodes[1])) {
       throw new InvalidArgumentException(
         "'list.filter' takes a lambda and a list as argument. Example: (list.filter (fn* (item idx) (= item 0)) my-list).",
       );
     }
     const [lambda, list] = nodes;
-    return {
-      type: ASTNodeType.LIST,
-      value: list.value.filter(
-        (node: ASTNodeList, value: number) =>
-          lambda.value([node, { type: ASTNodeType.NUMBER, value }]).value,
-      ),
-    };
+    return list.filter((value, idx) => lambda([value, idx]));
   },
 };

--- a/lib/std/math.test.ts
+++ b/lib/std/math.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { n } from "../../tests/utils.js";
-import { math } from "./math.js";
 import { type ASTNode, ASTNodeType } from "../types.js";
+import { math } from "./math.js";
 
 const num = (x: number) => n(ASTNodeType.NUMBER, x);
 const bool = (x: boolean) => n(ASTNodeType.BOOLEAN, x);

--- a/lib/std/math.test.ts
+++ b/lib/std/math.test.ts
@@ -1,25 +1,20 @@
 import { expect, test } from "bun:test";
-import { n } from "../../tests/utils.js";
-import { type ASTNode, ASTNodeType } from "../types.js";
 import { math } from "./math.js";
 
-const num = (x: number) => n(ASTNodeType.NUMBER, x);
-const bool = (x: boolean) => n(ASTNodeType.BOOLEAN, x);
-
 test("+", () => {
-  const tests: [string, ASTNode[], ASTNode][] = [
-    ["binary", [num(1), num(2)], num(3)],
-    ["n-ary", [num(1), num(2), num(3)], num(6)],
+  const tests: [string, any[], any][] = [
+    ["binary", [1, 2], 3],
+    ["n-ary", [1, 2, 3], 6],
   ];
   for (const [name, input, output] of tests) {
-    expect(math["+"](input), name).toEqual(output);
+    expect(math["+"](input), name).toBe(output);
   }
 });
 
 test("+ - errors", () => {
-  const tests: [string, ASTNode[]][] = [
-    ["unary", [num(1)]],
-    ["not numbers", [num(1), bool(false)]],
+  const tests: [string, any[]][] = [
+    ["unary", [1]],
+    ["not numbers", [1, false]],
   ];
   for (const [name, input] of tests) {
     expect(() => math["+"](input), name).toThrow();
@@ -27,19 +22,19 @@ test("+ - errors", () => {
 });
 
 test("*", () => {
-  const tests: [string, ASTNode[], ASTNode][] = [
-    ["binary", [num(1), num(2)], num(2)],
-    ["n-ary", [num(1), num(2), num(3)], num(6)],
+  const tests: [string, any[], any][] = [
+    ["binary", [1, 2], 2],
+    ["n-ary", [1, 2, 3], 6],
   ];
   for (const [name, input, output] of tests) {
-    expect(math["*"](input), name).toEqual(output);
+    expect(math["*"](input), name).toBe(output);
   }
 });
 
 test("* - errors", () => {
-  const tests: [string, ASTNode[]][] = [
-    ["unary", [num(1)]],
-    ["not numbers", [num(1), bool(false)]],
+  const tests: [string, any[]][] = [
+    ["unary", [1]],
+    ["not numbers", [1, false]],
   ];
   for (const [name, input] of tests) {
     expect(() => math["*"](input), name).toThrow();
@@ -47,20 +42,20 @@ test("* - errors", () => {
 });
 
 test("-", () => {
-  const tests: [string, ASTNode[], ASTNode][] = [
-    ["binary", [num(1), num(2)], num(-1)],
-    ["n-ary", [num(1), num(2), num(3)], num(-4)],
-    ["positive", [num(3), num(2)], num(1)],
+  const tests: [string, any[], any][] = [
+    ["binary", [1, 2], -1],
+    ["n-ary", [1, 2, 3], -4],
+    ["positive", [3, 2], 1],
   ];
   for (const [name, input, output] of tests) {
-    expect(math["-"](input), name).toEqual(output);
+    expect(math["-"](input), name).toBe(output);
   }
 });
 
 test("- - errors", () => {
-  const tests: [string, ASTNode[]][] = [
-    ["unary", [num(1)]],
-    ["not numbers", [num(1), bool(false)]],
+  const tests: [string, any[]][] = [
+    ["unary", [1]],
+    ["not numbers", [1, false]],
   ];
   for (const [name, input] of tests) {
     expect(() => math["-"](input), name).toThrow();
@@ -68,20 +63,20 @@ test("- - errors", () => {
 });
 
 test("/", () => {
-  const tests: [string, ASTNode[], ASTNode][] = [
-    ["binary", [num(1), num(2)], num(0.5)],
-    ["n-ary", [num(6), num(3), num(2)], num(1)],
-    ["zero", [num(6), num(0)], num(Infinity)],
+  const tests: [string, any[], any][] = [
+    ["binary", [1, 2], 0.5],
+    ["n-ary", [6, 3, 2], 1],
+    ["zero", [6, 0], Infinity],
   ];
   for (const [name, input, output] of tests) {
-    expect(math["/"](input), name).toEqual(output);
+    expect(math["/"](input), name).toBe(output);
   }
 });
 
 test("/ - errors", () => {
-  const tests: [string, ASTNode[]][] = [
-    ["unary", [num(1)]],
-    ["not numbers", [num(1), bool(false)]],
+  const tests: [string, any[]][] = [
+    ["unary", [1]],
+    ["not numbers", [1, false]],
   ];
   for (const [name, input] of tests) {
     expect(() => math["/"](input), name).toThrow();
@@ -89,93 +84,93 @@ test("/ - errors", () => {
 });
 
 test("=", () => {
-  const tests: [string, ASTNode[], ASTNode][] = [
-    ["success", [num(1), num(1)], bool(true)],
-    ["failure", [num(1), num(2)], bool(false)],
+  const tests: [string, any[], any][] = [
+    ["success", [1, 1], true],
+    ["failure", [1, 2], false],
   ];
   for (const [name, input, output] of tests) {
-    expect(math["="](input), name).toEqual(output);
+    expect(math["="](input), name).toBe(output);
   }
 });
 
 test("<", () => {
-  const tests: [string, ASTNode[], ASTNode][] = [
-    ["success", [num(1), num(2)], bool(true)],
-    ["failure", [num(2), num(2)], bool(false)],
+  const tests: [string, any[], any][] = [
+    ["success", [1, 2], true],
+    ["failure", [2, 2], false],
   ];
   for (const [name, input, output] of tests) {
-    expect(math["<"](input), name).toEqual(output);
+    expect(math["<"](input), name).toBe(output);
   }
 });
 
 test(">", () => {
-  const tests: [string, ASTNode[], ASTNode][] = [
-    ["success", [num(2), num(1)], bool(true)],
-    ["failure", [num(1), num(2)], bool(false)],
+  const tests: [string, any[], any][] = [
+    ["success", [2, 1], true],
+    ["failure", [1, 2], false],
   ];
   for (const [name, input, output] of tests) {
-    expect(math[">"](input), name).toEqual(output);
+    expect(math[">"](input), name).toBe(output);
   }
 });
 
 test("!=", () => {
-  const tests: [string, ASTNode[], ASTNode][] = [
-    ["success", [num(1), num(2)], bool(true)],
-    ["failure", [num(2), num(2)], bool(false)],
+  const tests: [string, any[], any][] = [
+    ["success", [1, 2], true],
+    ["failure", [2, 2], false],
   ];
   for (const [name, input, output] of tests) {
-    expect(math["!="](input), name).toEqual(output);
+    expect(math["!="](input), name).toBe(output);
   }
 });
 
 test("<=", () => {
-  const tests: [string, ASTNode[], ASTNode][] = [
-    ["success", [num(1), num(2)], bool(true)],
-    ["success", [num(2), num(2)], bool(true)],
-    ["failure", [num(2), num(1)], bool(false)],
+  const tests: [string, any[], any][] = [
+    ["success", [1, 2], true],
+    ["success", [2, 2], true],
+    ["failure", [2, 1], false],
   ];
   for (const [name, input, output] of tests) {
-    expect(math["<="](input), name).toEqual(output);
+    expect(math["<="](input), name).toBe(output);
   }
 });
 
 test(">=", () => {
-  const tests: [string, ASTNode[], ASTNode][] = [
-    ["failure", [num(1), num(2)], bool(false)],
-    ["success", [num(2), num(2)], bool(true)],
-    ["success", [num(2), num(1)], bool(true)],
+  const tests: [string, any[], any][] = [
+    ["failure", [1, 2], false],
+    ["success", [2, 2], true],
+    ["success", [2, 1], true],
   ];
   for (const [name, input, output] of tests) {
-    expect(math[">="](input), name).toEqual(output);
+    expect(math[">="](input), name).toBe(output);
   }
 });
 
 test("and", () => {
-  const tests: [string, ASTNode[], ASTNode][] = [
-    ["success", [bool(true), bool(true)], bool(true)],
-    ["failure", [bool(true), bool(false)], bool(false)],
+  const tests: [string, any[], any][] = [
+    ["success", [true, true], true],
+    ["failure", [true, false], false],
   ];
   for (const [name, input, output] of tests) {
-    expect(math.and(input), name).toEqual(output);
+    expect(math.and(input), name).toBe(output);
   }
 });
 
 test("or", () => {
-  const tests: [string, ASTNode[], ASTNode][] = [
-    ["success", [bool(true), bool(false)], bool(true)],
-    ["failure", [bool(false), bool(false)], bool(false)],
+  const tests: [string, any[], any][] = [
+    ["success", [true, false], true],
+    ["failure", [false, false], false],
   ];
   for (const [name, input, output] of tests) {
-    expect(math.or(input), name).toEqual(output);
+    expect(math.or(input), name).toBe(output);
   }
 });
 
 for (const fn of ["=", "<", ">", "!=", "<=", ">=", "and", "or"]) {
   test(`${fn} - errors`, () => {
-    const tests: [string, ASTNode[]][] = [
-      ["unary", [num(1)]],
-      ["n-ary", [num(1), num(2), num(3)]],
-      ["different types", [num(1), bool(false)]],
+    const tests: [string, any[]][] = [
+      ["unary", [1]],
+      ["n-ary", [1, 2, 3]],
+      ["different types", [1, false]],
     ];
     for (const [name, input] of tests) {
       expect(() => math[fn](input), name).toThrow();

--- a/lib/std/strings.test.ts
+++ b/lib/std/strings.test.ts
@@ -1,67 +1,29 @@
 import { expect, test } from "bun:test";
-import { l, n } from "../../tests/utils.js";
-import { ASTNodeType } from "../types.js";
 import { strings } from "./strings.js";
 
 test("string.length", () => {
-  expect(strings["string.length"]([n(ASTNodeType.STRING, "abc")])).toEqual(
-    n(ASTNodeType.NUMBER, 3),
-  );
-  expect(() => strings["string.length"]([n(ASTNodeType.NUMBER, 1)])).toThrow();
+  expect(strings["string.length"](["abc"])).toBe(3);
+  expect(() => strings["string.length"]([1])).toThrow();
 });
 
 test("string.join", () => {
-  const join = strings["string.join"];
-  expect(
-    join([
-      n(ASTNodeType.STRING, " "),
-      l([n(ASTNodeType.STRING, "a"), n(ASTNodeType.STRING, "b")]),
-    ]),
-  ).toEqual(n(ASTNodeType.STRING, "a b"));
-  expect(() => join([n(ASTNodeType.STRING, "a")])).toThrow();
-  expect(() =>
-    join([l([n(ASTNodeType.STRING, "a"), n(ASTNodeType.NUMBER, 1)])]),
-  ).toThrow();
+  expect(strings["string.join"]([" ", ["a", "b"]])).toBe("a b");
+  expect(() => strings["string.join"](["a"])).toThrow();
+  expect(() => strings["string.join"]([["a", 1]])).toThrow();
 });
 
 test("string.slice", () => {
-  const slice = strings["string.slice"];
-  expect(
-    slice([
-      n(ASTNodeType.STRING, "abcdef"),
-      n(ASTNodeType.NUMBER, 1),
-      n(ASTNodeType.NUMBER, 4),
-    ]),
-  ).toEqual(n(ASTNodeType.STRING, "bcd"));
-  expect(() =>
-    slice([n(ASTNodeType.STRING, "a"), n(ASTNodeType.NUMBER, 1)]),
-  ).toThrow();
+  expect(strings["string.slice"](["abcdef", 1, 4])).toBe("bcd");
+  expect(() => strings["string.slice"](["a", 1])).toThrow();
 });
 
 test("string.includes", () => {
-  expect(
-    strings["string.includes"]([
-      n(ASTNodeType.STRING, "abc"),
-      n(ASTNodeType.STRING, "b"),
-    ]),
-  ).toEqual(n(ASTNodeType.BOOLEAN, true));
-  expect(
-    strings["string.includes"]([
-      n(ASTNodeType.STRING, "abc"),
-      n(ASTNodeType.STRING, "z"),
-    ]),
-  ).toEqual(n(ASTNodeType.BOOLEAN, false));
-  expect(() =>
-    strings["string.includes"]([
-      n(ASTNodeType.STRING, "a"),
-      n(ASTNodeType.NUMBER, 1),
-    ]),
-  ).toThrow();
+  expect(strings["string.includes"](["abc", "b"])).toBe(true);
+  expect(strings["string.includes"](["abc", "z"])).toBe(false);
+  expect(() => strings["string.includes"](["a", 1])).toThrow();
 });
 
 test("string.trim", () => {
-  expect(strings["string.trim"]([n(ASTNodeType.STRING, "  abc  ")])).toEqual(
-    n(ASTNodeType.STRING, "abc"),
-  );
-  expect(() => strings["string.trim"]([n(ASTNodeType.NUMBER, 1)])).toThrow();
+  expect(strings["string.trim"](["  abc  "])).toBe("abc");
+  expect(() => strings["string.trim"]([1])).toThrow();
 });

--- a/lib/std/strings.test.ts
+++ b/lib/std/strings.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { l, n } from "../../tests/utils.js";
-import { strings } from "./strings.js";
 import { ASTNodeType } from "../types.js";
+import { strings } from "./strings.js";
 
 test("string.length", () => {
   expect(strings["string.length"]([n(ASTNodeType.STRING, "abc")])).toEqual(

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,12 +1,4 @@
-import {
-  type DEF,
-  type FN,
-  type IF,
-  KEYWORD_PREFIX,
-  type LET,
-  type LPAREN,
-  type RPAREN,
-} from "./constants.ts";
+import type { DEF, FN, IF, LET, LPAREN, RPAREN } from "./constants.ts";
 import type { Environment } from "./environment.js";
 
 export type Expression =
@@ -21,13 +13,8 @@ export enum ASTNodeType {
   NIL,
   STRING,
   SYMBOL,
-  KEYWORD,
   FUNCTION,
 }
-
-export type Keyword = `${typeof KEYWORD_PREFIX}${string}`;
-export const isKeyword = (s: string): s is Keyword =>
-  s.startsWith(KEYWORD_PREFIX);
 
 export type ASTNodeList = { type: ASTNodeType.LIST; value: ASTNode[] };
 export const isListNode = (n: ASTNode): n is ASTNodeList =>
@@ -39,12 +26,11 @@ export const isSymbol = (n: ASTNode): n is ASTNodeSymbol =>
 
 export type ASTNode =
   | ASTNodeList
+  | ASTNodeSymbol
   | { type: ASTNodeType.NUMBER; value: number }
   | { type: ASTNodeType.BOOLEAN; value: boolean }
   | { type: ASTNodeType.NIL; value: null }
-  | { type: ASTNodeType.STRING; value: string }
-  | ASTNodeSymbol
-  | { type: ASTNodeType.KEYWORD; value: Keyword };
+  | { type: ASTNodeType.STRING; value: string };
 
 export type AbstractSyntaxTree = ASTNode;
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,38 +1,45 @@
 import type { DEF, FN, IF, LET, LPAREN, RPAREN } from "./constants.ts";
 import type { Environment } from "./environment.js";
 
-export type Expression =
-  | ASTNode
-  | { type: ASTNodeType.LIST; value: Expression[] }
-  | { type: ASTNodeType.FUNCTION; value: Lambda };
+// Expressions
 
-export enum ASTNodeType {
+export type Lambda = (nodes: Value[]) => Value;
+export type Value = Value[] | number | boolean | null | string | Lambda;
+
+export const isNumber = (n: unknown): n is number => typeof n === "number";
+export const isString = (n: unknown): n is string => typeof n === "string";
+export const isBoolean = (n: unknown): n is boolean => typeof n === "boolean";
+export const isNull = (n: unknown): n is null => n == null;
+export const isLambda = (n: unknown): n is Lambda => typeof n === "function";
+export const isList = (n: unknown): n is Value[] => Array.isArray(n);
+
+// Abstract Syntax Tree
+
+export enum NodeType {
   LIST,
   NUMBER,
   BOOLEAN,
   NIL,
   STRING,
   SYMBOL,
-  FUNCTION,
 }
 
-export type ASTNodeList = { type: ASTNodeType.LIST; value: ASTNode[] };
-export const isListNode = (n: ASTNode): n is ASTNodeList =>
-  n.type === ASTNodeType.LIST;
+export type Node =
+  | NodeList
+  | NodeSymbol
+  | { type: NodeType.NUMBER; value: number }
+  | { type: NodeType.BOOLEAN; value: boolean }
+  | { type: NodeType.NIL; value: null }
+  | { type: NodeType.STRING; value: string };
 
-export type ASTNodeSymbol = { type: ASTNodeType.SYMBOL; value: string };
-export const isSymbol = (n: ASTNode): n is ASTNodeSymbol =>
-  n.type === ASTNodeType.SYMBOL;
+export type NodeList = { type: NodeType.LIST; value: Node[] };
+export const isListNode = (n: Node): n is NodeList => n.type === NodeType.LIST;
 
-export type ASTNode =
-  | ASTNodeList
-  | ASTNodeSymbol
-  | { type: ASTNodeType.NUMBER; value: number }
-  | { type: ASTNodeType.BOOLEAN; value: boolean }
-  | { type: ASTNodeType.NIL; value: null }
-  | { type: ASTNodeType.STRING; value: string };
+export type NodeSymbol = { type: NodeType.SYMBOL; value: string };
+export const isSymbol = (n: Node): n is NodeSymbol =>
+  n.type === NodeType.SYMBOL;
 
-export type AbstractSyntaxTree = ASTNode;
+// Tokenization
 
 export enum TokenType {
   LPAREN,
@@ -55,10 +62,10 @@ export type Token =
   | { type: TokenType.LPAREN; literal: typeof LPAREN }
   | { type: TokenType.RPAREN; literal: typeof RPAREN };
 
-export type Lambda = (nodes: Expression[]) => Expression;
+////
 
 export type SpecialFormType = typeof DEF | typeof FN | typeof LET | typeof IF;
 export type SpecialFormHandler = (
-  nodes: ASTNode[],
+  nodes: Node[],
   environment: Environment,
-) => Expression;
+) => Value;

--- a/tests/repl.test.ts
+++ b/tests/repl.test.ts
@@ -1,17 +1,17 @@
 import { expect, test } from "bun:test";
-import { read } from "../lib/read.ts";
-import { print } from "../lib/print.ts";
 import { defaultEnvironment, Environment } from "../lib/environment.ts";
 import { evaluate } from "../lib/index.ts";
+import { print } from "../lib/print.ts";
+import { read } from "../lib/read.ts";
 
 test("prints exactly what comes in", () => {
-  const input = '(1 :key "lol" true)';
+  const input = '(1 key "lol" true)';
   expect(print(read(input))).toEqual(input);
 });
 
 test("defines a variable and uses is", () => {
   const env = new Environment(defaultEnvironment);
-  evaluate(read("(def! :a 1)"), env);
+  evaluate(read("(def! a 1)"), env);
   const expr = evaluate(read("(+ a 1)"), env);
 
   expect(print(expr)).toEqual("2");
@@ -19,8 +19,8 @@ test("defines a variable and uses is", () => {
 
 test("defines a variable, a function and uses them", () => {
   const env = new Environment(defaultEnvironment);
-  evaluate(read("(def! :a 1)"), env);
-  evaluate(read("(def! :add (fn* (a b) (+ a b)))"), env);
+  evaluate(read("(def! a 1)"), env);
+  evaluate(read("(def! add (fn* (a b) (+ a b)))"), env);
   const expr = evaluate(read("(add 4 1)"), env);
 
   expect(print(expr)).toEqual("5");
@@ -28,9 +28,9 @@ test("defines a variable, a function and uses them", () => {
 
 test("implements cond", () => {
   const env = new Environment(defaultEnvironment);
-  evaluate(read("(def! :a 1)"), env);
+  evaluate(read("(def! a 1)"), env);
   evaluate(
-    read("(def! :cond2 (fn* (c1 b1 c2 b2 else) (if c1 b1 (if c2 b2 else))))"),
+    read("(def! cond2 (fn* (c1 b1 c2 b2 else) (if c1 b1 (if c2 b2 else))))"),
     env,
   );
 

--- a/tests/repl.test.ts
+++ b/tests/repl.test.ts
@@ -5,8 +5,8 @@ import { print } from "../lib/print.ts";
 import { read } from "../lib/read.ts";
 
 test("prints exactly what comes in", () => {
-  const input = '(1 key "lol" true)';
-  expect(print(read(input))).toEqual(input);
+  const input = '(1 "lol" true)';
+  expect(print(evaluate(read(input), defaultEnvironment))).toEqual(input);
 });
 
 test("defines a variable and uses is", () => {

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -20,8 +20,8 @@ afterEach(() => {
 
 test("variables across forms", () => {
   const script = `
-(def! :a 10)
-(def! :b (+ a 5))
+(def! a 10)
+(def! b (+ a 5))
 
 (io.printf "%d" ((+ a b)))
 `.trim();
@@ -31,8 +31,8 @@ test("variables across forms", () => {
 
 test("lambdas", () => {
   const script = `
-(def! :a 10)
-(def! :+5 (fn* (a) (+ a 5)))
+(def! a 10)
+(def! +5 (fn* (a) (+ a 5)))
 
 (io.printf "%d" ((+5 a)))
 `.trim();
@@ -42,8 +42,8 @@ test("lambdas", () => {
 
 test("lambdas and variables", () => {
   const script = `
-(def! :planet "world")
-(def! :greet
+(def! planet "world")
+(def! greet
   (fn* (name)
     (io.printf "Hello, %s!" (name))))
 
@@ -57,7 +57,7 @@ test("lambdas and variables", () => {
 
 test("special forms", () => {
   const script = `
-(def! :fibonacci
+(def! fibonacci
   (fn* (n) 
     (if (< n 2) 
       1 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,18 +1,18 @@
 import {
-  type ASTNode,
-  type ASTNodeList,
-  ASTNodeType,
+  type Node,
+  type NodeList,
+  NodeType,
   type Token,
   type TokenType,
 } from "../lib/types.js";
 
-// Creates an ASTNode. Short notation for tests
-export const n = (type: ASTNodeType, value: unknown): ASTNode =>
-  ({ type, value }) as ASTNode;
+// Creates an Node. Short notation for tests
+export const n = (type: NodeType, value: unknown): Node =>
+  ({ type, value }) as Node;
 
-// Creates an ASTNode List. Short notation for tests
-export const l = (elements: unknown[]): ASTNodeList =>
-  n(ASTNodeType.LIST, elements) as ASTNodeList;
+// Creates an NodeList. Short notation for tests
+export const l = (elements: unknown[]): NodeList =>
+  n(NodeType.LIST, elements) as NodeList;
 
 // Creates a Lexer Token. Short notation for tests
 export const t = (type: TokenType, literal?: string | number): Token =>


### PR DESCRIPTION
This pull request refactors the codebase to simplify type definitions and improve readability by replacing `ASTNodeType` and `Expression` with `NodeType` and `Value`. It also removes the `KEYWORD` type and updates related logic. The changes impact multiple files, including tests, core functionality, and special form handling.

### Type System Refactor:
* Replaced `ASTNodeType` and `Expression` with `NodeType` and `Value` across the codebase, simplifying type definitions and improving clarity.

### Removal of `KEYWORD` Type:
* Removed the `KEYWORD` type and its associated logic, simplifying the handling of symbols and improving consistency. For example, `ASTNodeType.KEYWORD` was removed, and special forms like `DEF` and `LET` now directly use symbols instead of keywords.

### Core Functionality Changes:
* Modified core functions like `evaluate`, `print`, and `read` to work with the simplified types. For instance, `evaluate` now directly returns primitive values instead of wrapping them in objects, and `print` handles raw values like `null` and arrays.