### PR TITLE
fix: improve memory utilization

### DIFF
--- a/examples/conway.lifp
+++ b/examples/conway.lifp
@@ -9,7 +9,7 @@
 (def! init-board
   ; Initializes the board
   (fn ()
-    (list:map 
+    (list:map
       (fn (a i) (if (> (math:random!) 0.5) 1 0))
       (list:times (fn (i) nil) BOARD_SIZE))))
 
@@ -86,3 +86,5 @@
 ; Main
 (def! board (init-board))
 (game-loop board)
+
+; vim:ft=lisp

--- a/examples/fact.lifp
+++ b/examples/fact.lifp
@@ -2,6 +2,6 @@
 ; The syntax is very similar to other LISPs you may be familiar with
 (def! fact (fn (n) (cond ((< n 1) 1) (* n (fact (- n 1))))))
 
-(io:print! (fact 50))
+(io:stdout! (fact 100))
 
 ; vim:ft=lisp

--- a/examples/fibonacci.lifp
+++ b/examples/fibonacci.lifp
@@ -9,6 +9,6 @@
       ((= a 2) 2)
       (+ (fibonacci (- a 1)) (fibonacci (- a 2))))))
 
-(io:print! (fibonacci 8))
+(io:stdout! (fibonacci 8))
 
 ; vim:ft=lisp

--- a/lib/arena.c
+++ b/lib/arena.c
@@ -71,3 +71,8 @@ void arenaDestroy(arena_t **self) {
 }
 
 void arenaReset(arena_t *self) { self->offset = 0; }
+
+frame_handle_t arenaStartFrame(arena_t *self) { return self->offset; }
+void arenaEndFrame(arena_t *self, frame_handle_t frame) {
+  self->offset = frame;
+}

--- a/lib/arena.h
+++ b/lib/arena.h
@@ -124,3 +124,6 @@ void arenaDestroy(arena_t **self);
  *   arenaReset(arena);  // All memory now available again
  */
 void arenaReset(arena_t *self);
+
+frame_handle_t arenaStartFrame(arena_t *self);
+void arenaEndFrame(arena_t *self, frame_handle_t frame);

--- a/lib/profile.c
+++ b/lib/profile.c
@@ -251,7 +251,7 @@ void profileReport(void) {
 #endif
 
 #if MEMORY_PROFILE_ARENA_ALLOCATIONS_SUMMARY == 1
-    printf("\n === Memory Metrics: Arena Allocationn Summary ===\n");
+    printf("\n === Memory Metrics: Arena Allocation Summary ===\n");
     printSpanSummary(ROOT_ARENA_SPAN);
 #endif
 

--- a/lib/profile.c
+++ b/lib/profile.c
@@ -182,18 +182,18 @@ void makeSpanSummary(const span_t *root, size_t *len, span_t *summary) {
   }
 
   if (!found) {
-    span_t *new_item = &summary[*len];
-    strcpy(new_item->label, root->label);
-    new_item->hits = root->hits;
-    new_item->total = root->total;
-    (*len)++;
-
     if (*len == MAX_SUMMARY_SPANS) {
       printf(
           "Profiling error: Maximum number (%lu) of summary spans reached.\n",
           MAX_SUMMARY_SPANS);
       return;
     }
+
+    span_t *new_item = &summary[*len];
+    strcpy(new_item->label, root->label);
+    new_item->hits = root->hits;
+    new_item->total = root->total;
+    (*len)++;
   }
 
   for (unsigned long i = 0; i < root->subspans_count; i++) {
@@ -206,10 +206,14 @@ void printSpanSummary(const span_t *root) {
   size_t count = 0;
   makeSpanSummary(root, &count, summary);
 
+  size_t total = 0;
   for (size_t i = 0; i < count; i++) {
     span_t span = summary[i];
+    total += span.total;
     printf(" %16s: %12lu bytes %6lu hits\n", span.label, span.total, span.hits);
   }
+  printf(" %16s\n", "---");
+  printf(" %16s: %12lu bytes\n", "Total", total);
 }
 
 void printArenas(void) {

--- a/lib/profile.h
+++ b/lib/profile.h
@@ -46,7 +46,7 @@
 
 #ifdef MEMORY_PROFILE
 
-// Upate these values for finer reports
+// Update these values for finer reports
 #define MEMORY_PROFILE_SAFE_ALLOC 0
 #define MEMORY_PROFILE_ARENA_ALLOCATIONS 0
 #define MEMORY_PROFILE_ARENA_ALLOCATIONS_SUMMARY 1

--- a/lib/profile.h
+++ b/lib/profile.h
@@ -45,11 +45,19 @@
 //
 
 #ifdef MEMORY_PROFILE
+
+// Upate these values for finer reports
+#define MEMORY_PROFILE_SAFE_ALLOC 0
+#define MEMORY_PROFILE_ARENA_ALLOCATIONS 0
+#define MEMORY_PROFILE_ARENA_ALLOCATIONS_SUMMARY 1
+#define MEMORY_PROFILE_ARENA_SATURATION 0
+
 #include "arena.h"
 #include "result.h"
 
 constexpr size_t MAX_SUBSPAN = 16;
 constexpr size_t SPAN_LABEL_LEN = 16;
+constexpr size_t MAX_SUMMARY_SPANS = 16;
 
 typedef struct span_t {
   char label[SPAN_LABEL_LEN];

--- a/lifp/evaluate.c
+++ b/lifp/evaluate.c
@@ -54,7 +54,7 @@ evaluateNodeList(value_list_t **result, size_t initial_index, node_list_t *list,
               *result);
 
   for (size_t i = initial_index; i < list->count; i++) {
-    auto node = listGet(node_t, list, i);
+    node_t node = listGet(node_t, list, i);
     value_t reduced;
     try(result_void_position_t,
         evaluate(&reduced, scratch_arena, scratch_arena, &node, environment));
@@ -73,140 +73,151 @@ result_void_position_t evaluate(value_t *result, arena_t *result_arena,
   result->position.column = node->position.column;
   result->position.line = node->position.line;
 
-  switch (node->type) {
-  case NODE_TYPE_BOOLEAN: {
-    tryWithMeta(result_void_position_t,
-                valueInit(result, result_arena, node->value.boolean),
-                result->position);
-    return ok(result_void_position_t);
-  }
-  case NODE_TYPE_NIL: {
-    tryWithMeta(result_void_position_t,
-                valueInit(result, result_arena, node->value.nil),
-                result->position);
-    return ok(result_void_position_t);
-  }
-  case NODE_TYPE_NUMBER: {
-    tryWithMeta(result_void_position_t,
-                valueInit(result, result_arena, node->value.number),
-                result->position);
-    return ok(result_void_position_t);
-  }
-  case NODE_TYPE_STRING: {
-    result->type = VALUE_TYPE_STRING;
-    size_t len = strlen(node->value.string);
-    string_t string = nullptr;
-    tryWithMeta(result_void_position_t, arenaAllocate(result_arena, len + 1),
-                node->position, string);
-    stringCopy(string, node->value.string, len + 1);
-    result->value.string = string;
-    return ok(result_void_position_t);
-  }
-  case NODE_TYPE_SYMBOL: {
-    const value_t *resolved_value =
-        environmentResolveSymbol(environment, node->value.symbol);
-
-    if (!resolved_value) {
-      throw(result_void_position_t, ERROR_CODE_REFERENCE_SYMBOL_NOT_FOUND,
-            result->position,
-            "Symbol '%s' cannot be found in the current environment",
-            node->value.symbol);
-    }
-
-    result->type = resolved_value->type;
-    result->value = resolved_value->value;
-    return ok(result_void_position_t);
-  }
-  case NODE_TYPE_LIST: {
-    const auto list = node->value.list;
-
-    if (list.count == 0) {
+  while (true) {
+    switch (node->type) {
+    case NODE_TYPE_BOOLEAN: {
       tryWithMeta(result_void_position_t,
-                  valueInitList(result, result_arena, 0U), node->position);
+                  valueInit(result, result_arena, node->value.boolean),
+                  result->position);
       return ok(result_void_position_t);
     }
-
-    node_t first_node = listGet(node_t, &list, 0);
-    value_t first_value;
-    try(result_void_position_t,
-        evaluate(&first_value, scratch_arena, scratch_arena, &first_node,
-                 environment));
-
-    value_t scratch_result = {
-        .position.column = node->position.column,
-        .position.line = node->position.line,
-    };
-
-    switch (first_value.type) {
-    case VALUE_TYPE_SPECIAL: {
-      special_form_t special = first_value.value.special;
-      try(result_void_position_t,
-          special(&scratch_result, &list, scratch_arena, environment));
+    case NODE_TYPE_NIL: {
       tryWithMeta(result_void_position_t,
-                  valueCopy(&scratch_result, result, result_arena),
-                  node->position);
+                  valueInit(result, result_arena, node->value.nil),
+                  result->position);
       return ok(result_void_position_t);
     }
-    case VALUE_TYPE_BUILTIN: {
-      // Start from 1 to drop builtin node
-      value_list_t *arguments = nullptr;
-      try(result_void_position_t,
-          evaluateNodeList(&arguments, 1, &node->value.list, scratch_arena,
-                           environment, node->position));
-
-      builtin_t builtin = first_value.value.builtin;
-      try(result_void_position_t,
-          builtin(&scratch_result, arguments, scratch_arena));
+    case NODE_TYPE_NUMBER: {
       tryWithMeta(result_void_position_t,
-                  valueCopy(&scratch_result, result, result_arena),
-                  node->position);
+                  valueInit(result, result_arena, node->value.number),
+                  result->position);
       return ok(result_void_position_t);
     }
-    case VALUE_TYPE_CLOSURE: {
-      // Start from 1 to drop closure node
-      value_list_t *arguments = nullptr;
-      try(result_void_position_t,
-          evaluateNodeList(&arguments, 1, &node->value.list, scratch_arena,
-                           environment, node->position));
-
-      closure_t closure = first_value.value.closure;
-      try(result_void_position_t,
-          invokeClosure(&scratch_result, closure, arguments, scratch_arena));
-      tryWithMeta(result_void_position_t,
-                  valueCopy(&scratch_result, result, result_arena),
-                  node->position);
+    case NODE_TYPE_STRING: {
+      result->type = VALUE_TYPE_STRING;
+      size_t len = strlen(node->value.string);
+      string_t string = nullptr;
+      tryWithMeta(result_void_position_t, arenaAllocate(result_arena, len + 1),
+                  node->position, string);
+      stringCopy(string, node->value.string, len + 1);
+      result->value.string = string;
       return ok(result_void_position_t);
     }
-    case VALUE_TYPE_NUMBER:
-    case VALUE_TYPE_LIST:
-    case VALUE_TYPE_NIL:
-    case VALUE_TYPE_STRING:
-    case VALUE_TYPE_BOOLEAN:
-    default: {
-      value_list_t *list_values = nullptr;
-      try(result_void_position_t,
-          evaluateNodeList(&list_values, 0, &node->value.list, scratch_arena,
-                           environment, node->position));
+    case NODE_TYPE_SYMBOL: {
+      const value_t *resolved_value =
+          environmentResolveSymbol(environment, node->value.symbol);
 
-      tryWithMeta(result_void_position_t,
-                  valueInit(result, result_arena, list_values->count),
-                  node->position);
-
-      for (size_t i = 0; i < list_values->count; i++) {
-        value_t value = listGet(value_t, list_values, i);
-        value_t duplicated;
-        tryWithMeta(result_void_position_t,
-                    valueCopy(&value, &duplicated, result_arena),
-                    value.position);
-        tryWithMeta(result_void_position_t,
-                    listAppend(value_t, result->value.list, &duplicated),
-                    value.position);
+      if (!resolved_value) {
+        throw(result_void_position_t, ERROR_CODE_REFERENCE_SYMBOL_NOT_FOUND,
+              result->position,
+              "Symbol '%s' cannot be found in the current environment",
+              node->value.symbol);
       }
+
+      result->type = resolved_value->type;
+      result->value = resolved_value->value;
       return ok(result_void_position_t);
     }
+    case NODE_TYPE_LIST: {
+      const auto list = node->value.list;
+
+      if (list.count == 0) {
+        tryWithMeta(result_void_position_t,
+                    valueInitList(result, result_arena, 0U), node->position);
+        return ok(result_void_position_t);
+      }
+
+      node_t first_node = listGet(node_t, &list, 0);
+      value_t first_value;
+      try(result_void_position_t,
+          evaluate(&first_value, scratch_arena, scratch_arena, &first_node,
+                   environment));
+
+      value_t scratch_result = {
+          .position.column = node->position.column,
+          .position.line = node->position.line,
+      };
+
+      switch (first_value.type) {
+      case VALUE_TYPE_SPECIAL: {
+        special_form_t special = first_value.value.special;
+        trampoline_t trampoline;
+        try(result_void_position_t,
+            special(&scratch_result, &list, scratch_arena, environment,
+                    &trampoline));
+        tryWithMeta(result_void_position_t,
+                    valueCopy(&scratch_result, result, result_arena),
+                    node->position);
+
+        if (trampoline.more) {
+          environment = trampoline.environment;
+          node = trampoline.node;
+          continue;
+        }
+
+        return ok(result_void_position_t);
+      }
+      case VALUE_TYPE_BUILTIN: {
+        // Start from 1 to drop builtin node
+        value_list_t *arguments = nullptr;
+        try(result_void_position_t,
+            evaluateNodeList(&arguments, 1, &node->value.list, scratch_arena,
+                             environment, node->position));
+
+        builtin_t builtin = first_value.value.builtin;
+        try(result_void_position_t,
+            builtin(&scratch_result, arguments, scratch_arena));
+        tryWithMeta(result_void_position_t,
+                    valueCopy(&scratch_result, result, result_arena),
+                    node->position);
+        return ok(result_void_position_t);
+      }
+      case VALUE_TYPE_CLOSURE: {
+        // Start from 1 to drop closure node
+        value_list_t *arguments = nullptr;
+        try(result_void_position_t,
+            evaluateNodeList(&arguments, 1, &node->value.list, scratch_arena,
+                             environment, node->position));
+
+        closure_t closure = first_value.value.closure;
+        try(result_void_position_t,
+            invokeClosure(&scratch_result, closure, arguments, scratch_arena));
+        tryWithMeta(result_void_position_t,
+                    valueCopy(&scratch_result, result, result_arena),
+                    node->position);
+        return ok(result_void_position_t);
+      }
+      case VALUE_TYPE_NUMBER:
+      case VALUE_TYPE_LIST:
+      case VALUE_TYPE_NIL:
+      case VALUE_TYPE_STRING:
+      case VALUE_TYPE_BOOLEAN:
+      default: {
+        value_list_t *list_values = nullptr;
+        try(result_void_position_t,
+            evaluateNodeList(&list_values, 0, &node->value.list, scratch_arena,
+                             environment, node->position));
+
+        tryWithMeta(result_void_position_t,
+                    valueInit(result, result_arena, list_values->count),
+                    node->position);
+
+        for (size_t i = 0; i < list_values->count; i++) {
+          value_t value = listGet(value_t, list_values, i);
+          value_t duplicated;
+          tryWithMeta(result_void_position_t,
+                      valueCopy(&value, &duplicated, result_arena),
+                      value.position);
+          tryWithMeta(result_void_position_t,
+                      listAppend(value_t, result->value.list, &duplicated),
+                      value.position);
+        }
+        return ok(result_void_position_t);
+      }
+      }
     }
-  }
-  default:
-    unreachable();
+    default:
+      unreachable();
+    }
   }
 }

--- a/lifp/evaluate.c
+++ b/lifp/evaluate.c
@@ -15,6 +15,7 @@
 result_void_position_t invokeClosure(value_t *result, closure_t closure,
                                      value_list_t *arguments,
                                      arena_t *scratch_arena) {
+  profileArena(scratch_arena);
   if (arguments->count < closure.arguments.count) {
     throw(result_void_position_t, ERROR_CODE_TYPE_UNEXPECTED_ARITY,
           closure.form.position,
@@ -68,7 +69,6 @@ result_void_position_t evaluate(value_t *result, arena_t *result_arena,
                                 environment_t *environment) {
   profileSafeAlloc();
   profileArena(scratch_arena);
-  profileArena(result_arena);
 
   result->position.column = node->position.column;
   result->position.line = node->position.line;

--- a/lifp/evaluate.c
+++ b/lifp/evaluate.c
@@ -163,16 +163,15 @@ result_void_position_t evaluate(value_t *result, arena_t *result_arena,
         try(result_void_position_t,
             special(&scratch_result, &list, scratch_arena, environment,
                     &trampoline));
-        tryWithMeta(result_void_position_t,
-                    valueCopy(&scratch_result, result, result_arena),
-                    node->position);
-
         if (trampoline.more) {
           environment = trampoline.environment;
           node = trampoline.node;
           tco = true;
           continue;
         }
+        tryWithMeta(result_void_position_t,
+                    valueCopy(&scratch_result, result, result_arena),
+                    node->position);
 
         return ok(result_void_position_t);
       }

--- a/lifp/evaluate.c
+++ b/lifp/evaluate.c
@@ -18,7 +18,7 @@ result_void_position_t invokeClosure(value_t *result, closure_t closure,
   profileArena(scratch_arena);
   if (arguments->count < closure.arguments.count) {
     throw(result_void_position_t, ERROR_CODE_TYPE_UNEXPECTED_ARITY,
-          closure.form.position,
+          closure.form->position,
           "Unexpected arity. Expected %lu arguments, got %lu.",
           closure.arguments.count, arguments->count);
   }
@@ -39,7 +39,7 @@ result_void_position_t invokeClosure(value_t *result, closure_t closure,
   }
 
   try(result_void_position_t, evaluate(result, scratch_arena, scratch_arena,
-                                       &closure.form, local_environment));
+                                       closure.form, local_environment));
 
   return ok(result_void_position_t);
 }

--- a/lifp/evaluate.c
+++ b/lifp/evaluate.c
@@ -16,11 +16,11 @@ result_void_position_t invokeClosure(value_t *result, closure_t closure,
                                      value_list_t *arguments,
                                      arena_t *scratch_arena) {
   profileArena(scratch_arena);
-  if (arguments->count < closure.arguments.count) {
+  if (arguments->count < closure.arguments->count) {
     throw(result_void_position_t, ERROR_CODE_TYPE_UNEXPECTED_ARITY,
           closure.form->position,
           "Unexpected arity. Expected %lu arguments, got %lu.",
-          closure.arguments.count, arguments->count);
+          closure.arguments->count, arguments->count);
   }
 
   environment_t *local_environment = nullptr;
@@ -29,8 +29,8 @@ result_void_position_t invokeClosure(value_t *result, closure_t closure,
               result->position, local_environment);
 
   // Populate the closure with the values, skipping the closure
-  for (size_t i = 0; i < closure.arguments.count; i++) {
-    auto argument = listGet(node_t, &closure.arguments, i);
+  for (size_t i = 0; i < closure.arguments->count; i++) {
+    auto argument = listGet(node_t, closure.arguments, i);
     auto value = listGet(value_t, arguments, i);
     tryWithMeta(result_void_position_t,
                 mapSet(value_t, local_environment->values,

--- a/lifp/evaluate.c
+++ b/lifp/evaluate.c
@@ -121,11 +121,8 @@ result_void_position_t evaluate(value_t *result, arena_t *result_arena,
     const auto list = node->value.list;
 
     if (list.count == 0) {
-      result->type = VALUE_TYPE_LIST;
-      result->value.list.count = 0;
-      result->value.list.capacity = 0;
-      result->value.list.data = nullptr;
-      result->value.list.arena = result_arena;
+      tryWithMeta(result_void_position_t,
+                  valueInitList(result, result_arena, 0U), node->position);
       return ok(result_void_position_t);
     }
 
@@ -202,7 +199,7 @@ result_void_position_t evaluate(value_t *result, arena_t *result_arena,
                     valueCopy(&value, &duplicated, result_arena),
                     value.position);
         tryWithMeta(result_void_position_t,
-                    listAppend(value_t, &result->value.list, &duplicated),
+                    listAppend(value_t, result->value.list, &duplicated),
                     value.position);
       }
       return ok(result_void_position_t);

--- a/lifp/evaluate.h
+++ b/lifp/evaluate.h
@@ -26,4 +26,5 @@ result_void_position_t evaluate(value_t *result, arena_t *result_arena,
 // location pointed to by `result`.
 result_void_position_t invokeClosure(value_t *result, closure_t closure,
                                      value_list_t *arguments,
-                                     arena_t *scratch_arena);
+                                     arena_t *scratch_arena,
+                                     trampoline_t *trampoline);

--- a/lifp/fmt.c
+++ b/lifp/fmt.c
@@ -130,16 +130,16 @@ void formatValue(const value_t *value, int size,
   }
   case VALUE_TYPE_LIST: {
     append(size, output_buffer, offset, "(");
-    value_list_t list = value->value.list;
+    value_list_t *list = value->value.list;
 
-    if (list.count > 0) {
-      for (size_t i = 0; i < list.count - 1; i++) {
-        value_t sub_value = listGet(value_t, &list, i);
+    if (list->count > 0) {
+      for (size_t i = 0; i < list->count - 1; i++) {
+        value_t sub_value = listGet(value_t, list, i);
         formatValue(&sub_value, size, output_buffer, offset);
         append(size, output_buffer, offset, " ");
       }
 
-      value_t sub_value = listGet(value_t, &list, list.count - 1);
+      value_t sub_value = listGet(value_t, list, list->count - 1);
       formatValue(&sub_value, size, output_buffer, offset);
     }
     append(size, output_buffer, offset, ")");

--- a/lifp/fmt.c
+++ b/lifp/fmt.c
@@ -147,16 +147,16 @@ void formatValue(const value_t *value, int size,
   }
   case VALUE_TYPE_CLOSURE:
     append(size, output_buffer, offset, "(fn (");
-    node_list_t arguments = value->value.closure.arguments;
+    node_list_t *arguments = value->value.closure.arguments;
 
-    if (arguments.count > 0) {
-      for (size_t i = 0; i < arguments.count - 1; i++) {
-        node_t sub_node = listGet(node_t, &arguments, i);
+    if (arguments->count > 0) {
+      for (size_t i = 0; i < arguments->count - 1; i++) {
+        node_t sub_node = listGet(node_t, arguments, i);
         formatNode(&sub_node, size, output_buffer, offset);
         append(size, output_buffer, offset, " ");
       }
 
-      node_t sub_node = listGet(node_t, &arguments, arguments.count - 1);
+      node_t sub_node = listGet(node_t, arguments, arguments->count - 1);
       formatNode(&sub_node, size, output_buffer, offset);
     }
     append(size, output_buffer, offset, ") ");

--- a/lifp/fmt.c
+++ b/lifp/fmt.c
@@ -161,7 +161,7 @@ void formatValue(const value_t *value, int size,
     }
     append(size, output_buffer, offset, ") ");
 
-    formatNode(&value->value.closure.form, size, output_buffer, offset);
+    formatNode(value->value.closure.form, size, output_buffer, offset);
     append(size, output_buffer, offset, ")");
   default:
   }

--- a/lifp/specials.c
+++ b/lifp/specials.c
@@ -118,7 +118,7 @@ result_void_position_t function(value_t *result, const node_list_t *nodes,
     }
 
     tryWithMeta(result_void_position_t,
-                listAppend(node_t, &result->value.closure.arguments, &argument),
+                listAppend(node_t, result->value.closure.arguments, &argument),
                 argument.position);
   }
 

--- a/lifp/specials.c
+++ b/lifp/specials.c
@@ -123,7 +123,7 @@ result_void_position_t function(value_t *result, const node_list_t *nodes,
   }
 
   tryWithMeta(result_void_position_t,
-              nodeCopy(&form, &result->value.closure.form, scratch_arena),
+              nodeCopy(&form, result->value.closure.form, scratch_arena),
               form.position);
 
   environment_t *captured = nullptr;

--- a/lifp/specials.c
+++ b/lifp/specials.c
@@ -147,6 +147,7 @@ const char *LET_EXAMPLE = "(let ((a 1) (b 2)) (+ a b))";
 result_void_position_t let(value_t *result, const node_list_t *nodes,
                            arena_t *scratch_arena, environment_t *environment,
                            trampoline_t *trampoline) {
+  (void)result;
   profileArena(scratch_arena);
   assert(nodes->count > 0); // let is always there
   node_t first = listGet(node_t, nodes, 0);
@@ -201,19 +202,9 @@ result_void_position_t let(value_t *result, const node_list_t *nodes,
         evaluated.position);
   }
 
-  node_t form = listGet(node_t, nodes, 2);
-  value_t temp_result;
-  try(result_void_position_t,
-      evaluate(&temp_result, scratch_arena, scratch_arena, &form, local_env));
-
-  // The result from the evaluation might be allocated in the local_env's arena,
-  // which will be destroyed. We need to copy it to the temp arena to allow
-  // expressions like `(let ((l (1 2))) l)` where values can escape the env
-  tryWithMeta(result_void_position_t,
-              valueCopy(&temp_result, result, scratch_arena),
-              temp_result.position);
-
-  trampoline->more = false;
+  trampoline->more = true;
+  trampoline->environment = local_env;
+  trampoline->node = &nodes->data[2];
   return ok(result_void_position_t);
 }
 

--- a/lifp/specials.h
+++ b/lifp/specials.h
@@ -4,16 +4,16 @@
 
 constexpr char DEFINE[] = "def!";
 result_void_position_t define(value_t *, const node_list_t *, arena_t *,
-                              environment_t *);
+                              environment_t *, trampoline_t *);
 
 constexpr char FUNCTION[] = "fn";
 result_void_position_t function(value_t *, const node_list_t *, arena_t *,
-                                environment_t *);
+                                environment_t *, trampoline_t *);
 
 constexpr char LET[] = "let";
 result_void_position_t let(value_t *, const node_list_t *, arena_t *,
-                           environment_t *);
+                           environment_t *, trampoline_t *);
 
 constexpr char COND[] = "cond";
 result_void_position_t cond(value_t *, const node_list_t *, arena_t *,
-                            environment_t *);
+                            environment_t *, trampoline_t *);

--- a/lifp/std/io.c
+++ b/lifp/std/io.c
@@ -118,7 +118,7 @@ result_void_position_t ioPrintf(value_t *result, const value_list_t *values,
           formatValueType(inputs_value.type));
   }
 
-  value_list_t inputs = inputs_value.value.list;
+  value_list_t *inputs = inputs_value.value.list;
   char *format = format_value.value.string;
 
   size_t placeholder_count = 0;
@@ -128,19 +128,19 @@ result_void_position_t ioPrintf(value_t *result, const value_list_t *values,
     placeholder_count++;
   }
 
-  if (placeholder_count > inputs.count) {
+  if (placeholder_count > inputs->count) {
     throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR,
           format_value.position,
           "Cannot have more placeholders than values. "
           "Got %lu placeholders and %lu values.",
-          placeholder_count, inputs.count);
+          placeholder_count, inputs->count);
   }
 
   size_t index = 0;
   const char *current = format;
   while (*current) {
     if (*current == '{' && *(current + 1) == '}') {
-      value_t value = listGet(value_t, &inputs, index);
+      value_t value = listGet(value_t, inputs, index);
       if (value.type != VALUE_TYPE_STRING) {
         char buffer[INTERMEDIATE_BUFFER_SIZE];
         int offset = 0;

--- a/lifp/std/list.c
+++ b/lifp/std/list.c
@@ -40,7 +40,7 @@ result_void_position_t listCount(value_t *result, const value_list_t *arguments,
   }
 
   result->type = VALUE_TYPE_NUMBER;
-  result->value.number = (number_t)list_value.value.list.count;
+  result->value.number = (number_t)list_value.value.list->count;
 
   return ok(result_void_position_t);
 }
@@ -62,7 +62,7 @@ result_void_position_t listFrom(value_t *result, const value_list_t *arguments,
   tryWithMeta(result_void_position_t,
               listCreate(value_t, arena, arguments->count), result->position,
               new_list);
-  result->value.list = *new_list;
+  result->value.list = new_list;
 
   if (arguments->count > 0) {
     // Copy all arguments to the new list
@@ -72,7 +72,7 @@ result_void_position_t listFrom(value_t *result, const value_list_t *arguments,
       tryWithMeta(result_void_position_t,
                   valueCopy(&source, &duplicated, arena), result->position);
       tryWithMeta(result_void_position_t,
-                  listAppend(value_t, &result->value.list, &duplicated),
+                  listAppend(value_t, result->value.list, &duplicated),
                   source.position);
     }
   } else {
@@ -118,7 +118,7 @@ result_void_position_t listNth(value_t *result, const value_list_t *arguments,
   }
 
   number_t index = index_value.value.number;
-  value_list_t *list = &list_value.value.list;
+  value_list_t *list = list_value.value.list;
 
   if (index < 0 || (size_t)index >= list->count ||
       index != (number_t)(size_t)index) {
@@ -165,7 +165,7 @@ result_void_position_t listMap(value_t *result, const value_list_t *arguments,
           LIST_MAP, formatValueType(list_value.type));
   }
 
-  value_list_t *input_list = &list_value.value.list;
+  value_list_t *input_list = list_value.value.list;
   closure_t closure = closure_value.value.closure;
 
   value_list_t *mapped_list = nullptr;
@@ -198,7 +198,7 @@ result_void_position_t listMap(value_t *result, const value_list_t *arguments,
   }
 
   result->type = VALUE_TYPE_LIST;
-  result->value.list = *mapped_list;
+  result->value.list = mapped_list;
 
   return ok(result_void_position_t);
 }
@@ -237,7 +237,7 @@ result_void_position_t listEach(value_t *result, const value_list_t *arguments,
           LIST_EACH, formatValueType(list_value.type));
   }
 
-  value_list_t *input_list = &list_value.value.list;
+  value_list_t *input_list = list_value.value.list;
   closure_t closure = closure_value.value.closure;
 
   for (size_t i = 0; i < input_list->count; i++) {
@@ -303,7 +303,7 @@ listFilter(value_t *result, const value_list_t *arguments, arena_t *arena) {
           LIST_FILTER, formatValueType(list_value.type));
   }
 
-  value_list_t *input_list = &list_value.value.list;
+  value_list_t *input_list = list_value.value.list;
   closure_t closure = closure_value.value.closure;
 
   value_list_t *filtered_list = nullptr;
@@ -346,7 +346,7 @@ listFilter(value_t *result, const value_list_t *arguments, arena_t *arena) {
   }
 
   result->type = VALUE_TYPE_LIST;
-  result->value.list = *filtered_list;
+  result->value.list = filtered_list;
 
   return ok(result_void_position_t);
 }
@@ -413,7 +413,7 @@ result_void_position_t listTimes(value_t *result, const value_list_t *arguments,
   }
 
   result->type = VALUE_TYPE_LIST;
-  result->value.list = *repeated_list;
+  result->value.list = repeated_list;
 
   return ok(result_void_position_t);
 }

--- a/lifp/std/list.c
+++ b/lifp/std/list.c
@@ -191,7 +191,7 @@ result_void_position_t listMap(value_t *result, const value_list_t *arguments,
 
     value_t mapped;
     try(result_void_position_t,
-        invokeClosure(&mapped, closure, closure_args, arena));
+        invokeClosure(&mapped, closure, closure_args, arena, nullptr));
 
     tryWithMeta(result_void_position_t,
                 listAppend(value_t, mapped_list, &mapped), result->position);
@@ -258,7 +258,7 @@ result_void_position_t listEach(value_t *result, const value_list_t *arguments,
 
     value_t mapped;
     try(result_void_position_t,
-        invokeClosure(&mapped, closure, closure_args, arena));
+        invokeClosure(&mapped, closure, closure_args, arena, nullptr));
   }
 
   result->type = VALUE_TYPE_NIL;
@@ -329,7 +329,7 @@ listFilter(value_t *result, const value_list_t *arguments, arena_t *arena) {
 
     value_t filtered;
     try(result_void_position_t,
-        invokeClosure(&filtered, closure, closure_args, arena));
+        invokeClosure(&filtered, closure, closure_args, arena, nullptr));
 
     if (filtered.type != VALUE_TYPE_BOOLEAN) {
       throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR_UNEXPECTED_TYPE,
@@ -406,7 +406,7 @@ result_void_position_t listTimes(value_t *result, const value_list_t *arguments,
 
     value_t mapped;
     try(result_void_position_t,
-        invokeClosure(&mapped, closure, closure_args, arena));
+        invokeClosure(&mapped, closure, closure_args, arena, nullptr));
 
     tryWithMeta(result_void_position_t,
                 listAppend(value_t, repeated_list, &mapped), result->position);

--- a/lifp/std/str.c
+++ b/lifp/std/str.c
@@ -88,7 +88,7 @@ result_void_position_t strJoin(value_t *result, const value_list_t *values,
           formatValueType(list_value.type));
   }
 
-  if (list_value.value.list.count == 0) {
+  if (list_value.value.list->count == 0) {
     string_t buffer;
     tryCreateBuffer(buffer, 1);
     result->type = VALUE_TYPE_STRING;
@@ -99,8 +99,8 @@ result_void_position_t strJoin(value_t *result, const value_list_t *values,
   size_t separator_length = strlen(separator_value.value.string);
 
   size_t total_length = 0;
-  for (size_t i = 0; i < list_value.value.list.count; i++) {
-    value_t current = listGet(value_t, &list_value.value.list, i);
+  for (size_t i = 0; i < list_value.value.list->count; i++) {
+    value_t current = listGet(value_t, list_value.value.list, i);
     if (current.type != VALUE_TYPE_STRING) {
       throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR_UNEXPECTED_TYPE,
             current.position, "%s requires a list of strings. Got %s.",
@@ -108,19 +108,19 @@ result_void_position_t strJoin(value_t *result, const value_list_t *values,
     }
     total_length += strlen(current.value.string);
   }
-  total_length += separator_length * (list_value.value.list.count - 1);
+  total_length += separator_length * (list_value.value.list->count - 1);
 
   string_t buffer;
   tryCreateBuffer(buffer, total_length + 1);
 
-  for (size_t i = 0; i < list_value.value.list.count - 1; i++) {
-    value_t current = listGet(value_t, &list_value.value.list, i);
+  for (size_t i = 0; i < list_value.value.list->count - 1; i++) {
+    value_t current = listGet(value_t, list_value.value.list, i);
     strcat(buffer, current.value.string);
     strcat(buffer, separator_value.value.string);
   }
 
   value_t last =
-      listGet(value_t, &list_value.value.list, list_value.value.list.count - 1);
+      listGet(value_t, list_value.value.list, list_value.value.list->count - 1);
   strcat(buffer, last.value.string);
 
   result->type = VALUE_TYPE_STRING;

--- a/lifp/value.c
+++ b/lifp/value.c
@@ -34,7 +34,7 @@ result_void_t valueInitClosure(value_t *self, arena_t *arena,
   node_t *form = nullptr;
   try(result_void_t, nodeCreate(arena, form_type), form);
   try(result_void_t, nodeInit(form, arena));
-  self->value.closure.form = *form;
+  self->value.closure.form = form;
 
   self->value.closure.captured_environment = nullptr;
 
@@ -120,9 +120,9 @@ result_void_t valueCopy(const value_t *source, value_t *destination,
     break;
   case VALUE_TYPE_CLOSURE:
     try(result_void_t, valueInitClosure(destination, destination_arena,
-                                        source->value.closure.form.type));
+                                        source->value.closure.form->type));
     try(result_void_t,
-        nodeCopy(&source->value.closure.form, &destination->value.closure.form,
+        nodeCopy(source->value.closure.form, destination->value.closure.form,
                  destination_arena));
     for (size_t i = 0; i < source->value.closure.arguments.count; i++) {
       node_t value = source->value.closure.arguments.data[i];

--- a/lifp/value.c
+++ b/lifp/value.c
@@ -18,9 +18,7 @@ result_ref_t valueCreate(arena_t *arena, value_type_t type) {
 
 result_void_t valueInitList(value_t *self, arena_t *arena, size_t size) {
   self->type = VALUE_TYPE_LIST;
-  value_list_t *list = nullptr;
-  try(result_void_t, listCreate(value_t, arena, size), list);
-  memcpy(&self->value.list, list, sizeof(value_list_t));
+  try(result_void_t, listCreate(value_t, arena, size), self->value.list);
   return ok(result_void_t);
 }
 
@@ -136,14 +134,14 @@ result_void_t valueCopy(const value_t *source, value_t *destination,
         destination->value.closure.captured_environment);
     break;
   case VALUE_TYPE_LIST: {
-    try(result_void_t, valueInitList(destination, destination_arena,
-                                     source->value.list.count));
-    for (size_t i = 0; i < source->value.list.count; i++) {
-      value_t value = listGet(value_t, &source->value.list, i);
+    try(result_void_t,
+        valueInit(destination, destination_arena, source->value.list->count));
+    for (size_t i = 0; i < source->value.list->count; i++) {
+      value_t value = listGet(value_t, source->value.list, i);
       value_t duplicated;
       try(result_void_t, valueCopy(&value, &duplicated, destination_arena));
       try(result_void_t,
-          listAppend(value_t, &destination->value.list, &duplicated));
+          listAppend(value_t, destination->value.list, &duplicated));
     }
     break;
   }

--- a/lifp/value.c
+++ b/lifp/value.c
@@ -27,14 +27,11 @@ result_void_t valueInitList(value_t *self, arena_t *arena, size_t size) {
 result_void_t valueInitClosure(value_t *self, arena_t *arena,
                                node_type_t form_type) {
   self->type = VALUE_TYPE_CLOSURE;
-  node_list_t *arguments = nullptr;
-  try(result_void_t, listCreate(node_t, arena, 2), arguments);
-  self->value.closure.arguments = *arguments;
+  try(result_void_t, listCreate(node_t, arena, 2),
+      self->value.closure.arguments);
 
-  node_t *form = nullptr;
-  try(result_void_t, nodeCreate(arena, form_type), form);
-  try(result_void_t, nodeInit(form, arena));
-  self->value.closure.form = form;
+  try(result_void_t, nodeCreate(arena, form_type), self->value.closure.form);
+  try(result_void_t, nodeInit(self->value.closure.form, arena));
 
   self->value.closure.captured_environment = nullptr;
 
@@ -124,12 +121,12 @@ result_void_t valueCopy(const value_t *source, value_t *destination,
     try(result_void_t,
         nodeCopy(source->value.closure.form, destination->value.closure.form,
                  destination_arena));
-    for (size_t i = 0; i < source->value.closure.arguments.count; i++) {
-      node_t value = source->value.closure.arguments.data[i];
+    for (size_t i = 0; i < source->value.closure.arguments->count; i++) {
+      node_t value = source->value.closure.arguments->data[i];
       node_t duplicated;
       try(result_void_t, nodeCopy(&value, &duplicated, destination_arena));
       try(result_void_t,
-          listAppend(node_t, &destination->value.closure.arguments,
+          listAppend(node_t, destination->value.closure.arguments,
                      &duplicated));
     }
 

--- a/lifp/value.h
+++ b/lifp/value.h
@@ -33,7 +33,7 @@ typedef enum {
 
 typedef struct {
   node_t *form;
-  node_list_t arguments;
+  node_list_t *arguments;
   environment_t *captured_environment;
 } closure_t;
 

--- a/lifp/value.h
+++ b/lifp/value.h
@@ -11,14 +11,21 @@
 
 typedef struct value_t value_t;
 typedef struct environment_t environment_t;
+typedef struct {
+  bool more;
+  environment_t *environment;
+  node_t *node;
+} trampoline_t;
 
 typedef List(value_t) value_list_t;
 typedef Result(value_t *, position_t) result_value_ref_t;
 typedef ResultVoid(position_t) result_void_position_t;
+
 typedef result_void_position_t (*builtin_t)(value_t *, const value_list_t *,
                                             arena_t *);
 typedef result_void_position_t (*special_form_t)(value_t *, const node_list_t *,
-                                                 arena_t *, environment_t *);
+                                                 arena_t *, environment_t *,
+                                                 trampoline_t *);
 
 typedef enum {
   VALUE_TYPE_BOOLEAN,

--- a/lifp/value.h
+++ b/lifp/value.h
@@ -46,7 +46,7 @@ typedef struct value_t {
     closure_t closure;
     builtin_t builtin;
     nullptr_t nil;
-    value_list_t list;
+    value_list_t *list;
     special_form_t special;
     string_t string;
   } value;

--- a/lifp/value.h
+++ b/lifp/value.h
@@ -32,7 +32,7 @@ typedef enum {
 } value_type_t;
 
 typedef struct {
-  node_t form;
+  node_t *form;
   node_list_t arguments;
   environment_t *captured_environment;
 } closure_t;

--- a/tests/evaluate.test.c
+++ b/tests/evaluate.test.c
@@ -80,10 +80,10 @@ void listOfElements() {
   evaluateAndClean(&result, &list_node);
   expectEqlValueType(result.type, VALUE_TYPE_LIST,
                      "has correct type");
-  value_list_t reduced_list = result.value.list;
-  expectEqlSize(reduced_list.count, 2, "has correct count");
-  for (size_t i = 0; i < reduced_list.count; i++) {
-    value_t node = listGet(value_t, &reduced_list, i);
+  value_list_t *reduced_list = result.value.list;
+  expectEqlSize(reduced_list->count, 2, "has correct count");
+  for (size_t i = 0; i < reduced_list->count; i++) {
+    value_t node = listGet(value_t, reduced_list, i);
     node_t expected_node = listGet(node_t, expected, i);
     expectEqlValueType(node.type, VALUE_TYPE_NUMBER, "has correct type");
     expectEqlDouble(node.value.number, expected_node.value.number,
@@ -151,9 +151,9 @@ void nested() {
   evaluateAndClean(&result, &outer_list_node);
   expectEqlValueType(result.type, VALUE_TYPE_LIST,
                      "has correct type");
-  expectEqlSize(result.value.list.count, 2, "has correct count");
-  value_t first = listGet(value_t, &result.value.list, 0);
-  value_t second = listGet(value_t, &result.value.list, 1);
+  expectEqlSize(result.value.list->count, 2, "has correct count");
+  value_t first = listGet(value_t, result.value.list, 0);
+  value_t second = listGet(value_t, result.value.list, 1);
   expectEqlValueType(first.type, VALUE_TYPE_NUMBER, "has correct type");
   expectEqlValueType(second.type, VALUE_TYPE_LIST, "has correct type");
 }
@@ -168,7 +168,7 @@ void emptyList() {
   value_t result;
   evaluateAndClean(&result, &empty_list_node);
   expectEqlValueType(result.type, VALUE_TYPE_LIST, "has correct type");
-  expectEqlSize(result.value.list.count, 0, "has correct count");
+  expectEqlSize(result.value.list->count, 0, "has correct count");
 }
 
 void allocations() {

--- a/tests/fmt.test.c
+++ b/tests/fmt.test.c
@@ -56,8 +56,8 @@ void values() {
   arenaReset(test_arena);
   value_t list_value;
   tryAssert(valueInit(&list_value, test_arena, (size_t)2));
-  tryAssert(listAppend(value_t, &list_value.value.list, &number));
-  tryAssert(listAppend(value_t, &list_value.value.list, &nil));
+  tryAssert(listAppend(value_t, list_value.value.list, &number));
+  tryAssert(listAppend(value_t, list_value.value.list, &nil));
 
   formatValue(&list_value, size, buffer, &offset);
   expectEqlString(buffer, "(123 nil)", 10, "formats lists");

--- a/tests/fmt.test.c
+++ b/tests/fmt.test.c
@@ -72,7 +72,7 @@ void values() {
 
   tryAssert(
       listAppend(node_t, &closure_value.value.closure.arguments, &symbol));
-  tryAssert(listAppend(node_t, &closure_value.value.closure.form.value.list,
+  tryAssert(listAppend(node_t, &closure_value.value.closure.form->value.list,
                        &symbol));
 
   formatValue(&closure_value, size, buffer, &offset);

--- a/tests/fmt.test.c
+++ b/tests/fmt.test.c
@@ -70,8 +70,7 @@ void values() {
 
   node_t symbol = nSym(test_arena, "a");
 
-  tryAssert(
-      listAppend(node_t, &closure_value.value.closure.arguments, &symbol));
+  tryAssert(listAppend(node_t, closure_value.value.closure.arguments, &symbol));
   tryAssert(listAppend(node_t, &closure_value.value.closure.form->value.list,
                        &symbol));
 

--- a/tests/integration.test.c
+++ b/tests/integration.test.c
@@ -138,6 +138,20 @@ int main() {
   expectEqlUint(currying.type, VALUE_TYPE_NUMBER, "returns a number");
   expectEqlDouble(currying.value.number, 5, "it has correct value");
 
+  case("expanding environment");
+  value_t environment;
+  execute(&environment, 
+      "(def! aa 1)\n"
+      "(def! ab 1)\n"
+      "(def! ac 1)\n"
+      "(def! ad 1)\n"
+      "(def! ae 1)\n"
+      "(def! af 1)\n"
+      "(def! ag 1)\n"
+      "(def! ah 1)\n"
+      "(def! ai 1)\n");
+  expectEqlUint(environment.type, VALUE_TYPE_NIL, "allows environment growth");
+
   arenaDestroy(&ast_arena);
   arenaDestroy(&scratch_arena);
   arenaDestroy(&result_arena);

--- a/tests/integration.test.c
+++ b/tests/integration.test.c
@@ -110,6 +110,12 @@ int main() {
   expectEqlUint(let.type, VALUE_TYPE_NUMBER, "returns correct type");
   expectEqlDouble(let.value.number, 2, "returns correct value");
 
+  case("let with escape");
+  value_t let_with_escape;
+  execute(&let_with_escape, "(+ 1 (let ((l 1)) l))");
+  expectEqlUint(let_with_escape.type, VALUE_TYPE_NUMBER, "returns correct type");
+  expectEqlDouble(let_with_escape.value.number, 2, "returns correct value");
+
   case("conditional - cond special form");
   value_t cond_test;
   execute(&cond_test, "(cond ((< 5 3) 1) ((> 5 3) 2) (3))");

--- a/tests/integration.test.c
+++ b/tests/integration.test.c
@@ -63,25 +63,25 @@ int main() {
   case("list");
   value_t list;
   execute(&list, "(1 2)");
-  expectEqlUint((unsigned int)list.value.list.count, 2, "returns a list"); 
-  value_t first = listGet(value_t, &list.value.list,  0); 
+  expectEqlUint((unsigned int)list.value.list->count, 2, "returns a list"); 
+  value_t first = listGet(value_t, list.value.list,  0); 
   expectEqlDouble(first.value.number, 1, "correct first item"); 
-  value_t second = listGet(value_t, &list.value.list, 1);
+  value_t second = listGet(value_t, list.value.list, 1);
   expectEqlDouble(second.value.number, 2, "correct second item");
   
   case("nested list");
   value_t nested_list;
   execute(&nested_list, "((1) 2)");
   expectEqlUint(nested_list.type, VALUE_TYPE_LIST, "returns a list");
-  expectEqlUint(nested_list.value.list.data[0].type, VALUE_TYPE_LIST, "with nested list");
-  expectEqlUint(nested_list.value.list.data[0].value.list.data->type, VALUE_TYPE_NUMBER, "with correct type");
+  expectEqlUint(nested_list.value.list->data[0].type, VALUE_TYPE_LIST, "with nested list");
+  expectEqlUint(nested_list.value.list->data[0].value.list->data->type, VALUE_TYPE_NUMBER, "with correct type");
 
   case("immediate invocation");
   value_t immediate_invocation;
   execute(&immediate_invocation, "((fn (a b) (list:from a b)) 2 3)");
   expectEqlUint(immediate_invocation.type, VALUE_TYPE_LIST, "returns a list");
-  expectTrue((immediate_invocation.value.list.data[0].value.number == 2 && 
-    immediate_invocation.value.list.data[1].value.number == 3) != 0, "with correct value");
+  expectTrue((immediate_invocation.value.list->data[0].value.number == 2 && 
+    immediate_invocation.value.list->data[1].value.number == 3) != 0, "with correct value");
 
   case("simple form");
   value_t simple;
@@ -130,7 +130,7 @@ int main() {
   value_t empty_list;
   execute(&empty_list, "()");
   expectEqlUint(empty_list.type, VALUE_TYPE_LIST, "empty list has correct type");
-  expectEqlUint((unsigned int)empty_list.value.list.count, 0, "empty list has zero elements");
+  expectEqlUint((unsigned int)empty_list.value.list->count, 0, "empty list has zero elements");
 
   case("currying");
   value_t currying;

--- a/tests/specials.test.c
+++ b/tests/specials.test.c
@@ -47,9 +47,9 @@ void defSpecialForm() {
 
   tryAssert(execute(&result, "(def! list (1 2))"));
   value = mapGet(value_t, environment->values, "list");
-  expectTrue((value->value.list.count == 2 &&
-              value->value.list.data[0].value.number == 1 &&
-              value->value.list.data[1].value.number == 2) != 0,
+  expectTrue((value->value.list->count == 2 &&
+              value->value.list->data[0].value.number == 1 &&
+              value->value.list->data[1].value.number == 2) != 0,
              "defines list");
 
   tryAssert(execute(&result, "(def! fun (fn (a b) (+ a b)))"));
@@ -144,9 +144,9 @@ void letSpecialForm() {
   expectEqlUint(result.type, VALUE_TYPE_NIL, "defines null");
 
   tryAssert(execute(&result, "(let ((l (1 \"2\"))) l)"));
-  expectTrue((result.value.list.count == 2 &&
-              result.value.list.data[0].value.number == 1 &&
-              strcmp(result.value.list.data[1].value.string, "2") == 0) != 0,
+  expectTrue((result.value.list->count == 2 &&
+              result.value.list->data[0].value.number == 1 &&
+              strcmp(result.value.list->data[1].value.string, "2") == 0) != 0,
              "defines lists");
 
   tryAssert(execute(&result, "(let ((f (fn (x y) (+ x y)))) f)"));

--- a/tests/specials.test.c
+++ b/tests/specials.test.c
@@ -56,9 +56,9 @@ void defSpecialForm() {
   value = mapGet(value_t, environment->values, "fun");
   expectTrue(
       (value->type == VALUE_TYPE_CLOSURE &&
-       value->value.closure.arguments.count == 2 &&
-       strcmp(value->value.closure.arguments.data[0].value.symbol, "a") == 0 &&
-       strcmp(value->value.closure.arguments.data[1].value.symbol, "b") == 0 &&
+       value->value.closure.arguments->count == 2 &&
+       strcmp(value->value.closure.arguments->data[0].value.symbol, "a") == 0 &&
+       strcmp(value->value.closure.arguments->data[1].value.symbol, "b") == 0 &&
        value->value.closure.form->value.list.count == 3) != 0,
       "defines function");
 
@@ -93,7 +93,7 @@ void fnSpecialForm() {
   tryAssert(execute(&result, "(fn (x y) (+ x y))"));
 
   expectEqlUint(result.type, VALUE_TYPE_CLOSURE, "creates closure");
-  expectEqlSize(result.value.closure.arguments.count, 2,
+  expectEqlSize(result.value.closure.arguments->count, 2,
                 "with correct argument count");
   expectEqlUint(result.value.closure.form->type, NODE_TYPE_LIST,
                 "with correct form type");
@@ -152,9 +152,9 @@ void letSpecialForm() {
   tryAssert(execute(&result, "(let ((f (fn (x y) (+ x y)))) f)"));
   closure_t closure = result.value.closure;
   expectTrue(
-      (closure.arguments.count == 2 &&
-       strcmp(closure.arguments.data[0].value.symbol, "x") == 0 &&
-       strcmp(closure.arguments.data[1].value.symbol, "y") == 0 &&
+      (closure.arguments->count == 2 &&
+       strcmp(closure.arguments->data[0].value.symbol, "x") == 0 &&
+       strcmp(closure.arguments->data[1].value.symbol, "y") == 0 &&
        closure.form->value.list.count == 3 &&
        strcmp(closure.form->value.list.data[0].value.symbol, "+") == 0 &&
        strcmp(closure.form->value.list.data[1].value.symbol, "x") == 0 &&

--- a/tests/specials.test.c
+++ b/tests/specials.test.c
@@ -59,7 +59,7 @@ void defSpecialForm() {
        value->value.closure.arguments.count == 2 &&
        strcmp(value->value.closure.arguments.data[0].value.symbol, "a") == 0 &&
        strcmp(value->value.closure.arguments.data[1].value.symbol, "b") == 0 &&
-       value->value.closure.form.value.list.count == 3) != 0,
+       value->value.closure.form->value.list.count == 3) != 0,
       "defines function");
 
   tryFail(execute(&result, "(def! num 2)"), exec);
@@ -95,7 +95,7 @@ void fnSpecialForm() {
   expectEqlUint(result.type, VALUE_TYPE_CLOSURE, "creates closure");
   expectEqlSize(result.value.closure.arguments.count, 2,
                 "with correct argument count");
-  expectEqlUint(result.value.closure.form.type, NODE_TYPE_LIST,
+  expectEqlUint(result.value.closure.form->type, NODE_TYPE_LIST,
                 "with correct form type");
 
   tryFail(execute(&result, "(fn (x 1) (+ x y))"), exec);
@@ -151,15 +151,15 @@ void letSpecialForm() {
 
   tryAssert(execute(&result, "(let ((f (fn (x y) (+ x y)))) f)"));
   closure_t closure = result.value.closure;
-  expectTrue((closure.arguments.count == 2 &&
-              strcmp(closure.arguments.data[0].value.symbol, "x") == 0 &&
-              strcmp(closure.arguments.data[1].value.symbol, "y") == 0 &&
-              closure.form.value.list.count == 3 &&
-              strcmp(closure.form.value.list.data[0].value.symbol, "+") == 0 &&
-              strcmp(closure.form.value.list.data[1].value.symbol, "x") == 0 &&
-              strcmp(closure.form.value.list.data[2].value.symbol, "y") == 0) !=
-                 0,
-             "defines functions");
+  expectTrue(
+      (closure.arguments.count == 2 &&
+       strcmp(closure.arguments.data[0].value.symbol, "x") == 0 &&
+       strcmp(closure.arguments.data[1].value.symbol, "y") == 0 &&
+       closure.form->value.list.count == 3 &&
+       strcmp(closure.form->value.list.data[0].value.symbol, "+") == 0 &&
+       strcmp(closure.form->value.list.data[1].value.symbol, "x") == 0 &&
+       strcmp(closure.form->value.list.data[2].value.symbol, "y") == 0) != 0,
+      "defines functions");
 
   value_t *leaked_a = mapGet(value_t, environment->values, "a");
   value_t *leaked_b = mapGet(value_t, environment->values, "b");


### PR DESCRIPTION
This change aims at improving, again, memory optimization. I'll track the improvements here for posterity.

## Data
I will use the following fibonacci implementation to assess if we are improving anything.
```lisp
(def! fibonacci
  (fn (a)
    (cond
      ((< a 1) 0)
      ((= a 1) 1)
      ((= a 2) 2)
      (+ (fibonacci (- a 1)) (fibonacci (- a 2))))))

(io:stdout! (fibonacci 8))
```

## Results memory
<details>
<summary>Initial (5629744 bytes)</summary>
<pre>
 === Memory Metrics: Arena Allocationn Summary ===
              root:           142040 bytes      1 hits
          evaluate:          3396992 bytes    852 hits
     invokeClosure:          1036144 bytes     41 hits
              cond:          1005312 bytes     41 hits
            define:            39408 bytes      1 hits
          function:             9848 bytes      1 hits
</pre>
</details>

<details>
<summary>With `cond` frames (3241904 bytes, -43%)</summary>
<pre>
 === Memory Metrics: Arena Allocationn Summary ===
              root:            90520 bytes      1 hits
          evaluate:          1964288 bytes    852 hits
     invokeClosure:           558576 bytes     41 hits
              cond:           579264 bytes     41 hits
            define:            39408 bytes      1 hits
          function:             9848 bytes      1 hits
</pre>
</details>

<details>
<summary>With `def!` frame (3163088 bytes, -44%)</summary>
<pre>
 === Memory Metrics: Arena Allocationn Summary ===
              root:            70816 bytes      1 hits
          evaluate:          1924880 bytes    852 hits
     invokeClosure:           558576 bytes     41 hits
              cond:           579264 bytes     41 hits
            define:            19704 bytes      1 hits
          function:             9848 bytes      1 hits
</pre>
</details>


<details>
<summary>Using node_t pointers for forms in closures (2108608 bytes, -63%)</summary>
<pre>
 === Memory Metrics: Arena Allocationn Summary ===
              root:            70816 bytes      1 hits
          evaluate:          1924880 bytes    852 hits
     invokeClosure:           558576 bytes     41 hits
              cond:           579264 bytes     41 hits
            define:            19704 bytes      1 hits
          function:             9848 bytes      1 hits
</pre>
</details>

<details>
<summary>Using node_list_t pointers for arguments in closures (1807328 bytes, -68%)</summary>
<pre>
 === Memory Metrics: Arena Allocationn Summary ===
             root:        40000 bytes      1 hits
         evaluate:      1097096 bytes    852 hits
    invokeClosure:       316944 bytes     41 hits
             cond:       324600 bytes     41 hits
           define:        19128 bytes      1 hits
         function:         9560 bytes      1 hits
</pre>
</details>

<details>
<summary>Using value_list_t pointers (1506048 bytes, -74%)</summary>
<pre>
=== Memory Metrics: Arena Allocationn Summary ===
             root:        33152 bytes      1 hits
         evaluate:       913144 bytes    852 hits
    invokeClosure:       263248 bytes     41 hits
             cond:       268008 bytes     41 hits
           define:        19000 bytes      1 hits
         function:         9496 bytes      1 hits
</pre>
</details>

<details>
<summary>TCO for cond (1012352 bytes, -82%)</summary>
<pre>
 === Memory Metrics: Arena Allocationn Summary ===
             root:        33152 bytes      1 hits
         evaluate:       666296 bytes    811 hits
    invokeClosure:       263248 bytes     41 hits
             cond:        21160 bytes     41 hits
           define:        19000 bytes      1 hits
         function:         9496 bytes      1 hits
</pre>
</details>

<details>
<summary>TCO for closures (518656 bytes, -91%)</summary>
<pre>
 === Memory Metrics: Arena Allocationn Summary ===
             root:        33152 bytes      1 hits
         evaluate:       419448 bytes    770 hits
    invokeClosure:        16400 bytes     41 hits
             cond:        21160 bytes     41 hits
           define:        19000 bytes      1 hits
         function:         9496 bytes      1 hits
              ---
            Total:       518656 bytes
</pre>
</details>

## Results time

> Using hyperfine, but it wouldn't be the worst idea to make our time profiler too...

<details>
<summary>Initial (avg 57.6ms)</summary>
<pre>
$ hyperfine --warmup 100 'bin/lifp run examples/fibonacci.lifp'
Benchmark 1: bin/lifp run examples/fibonacci.lifp
  Time (mean ± σ):      57.6 ms ±   2.0 ms    [User: 8.6 ms, System: 42.4 ms]
  Range (min … max):    54.0 ms …  61.8 ms    49 runs
</pre>
</details>

<details>
<summary>Using node_list_t pointers for arguments in closures (avg 51.7ms)</summary>
<pre>
$ hyperfine --warmup 100 'bin/lifp run examples/fibonacci.lifp'
Benchmark 1: bin/lifp run examples/fibonacci.lifp
  Time (mean ± σ):      51.7 ms ±   1.4 ms    [User: 8.4 ms, System: 34.2 ms]
  Range (min … max):    49.4 ms …  55.0 ms    52 runs
</pre>
</details>

<details>
<summary>Using value_list_t pointers (avg 50.6ms)</summary>
<pre>
$ hyperfine --warmup 100 'bin/lifp run examples/fibonacci.lifp'
Benchmark 1: bin/lifp run examples/fibonacci.lifp
  Time (mean ± σ):      50.6 ms ±   1.2 ms    [User: 8.5 ms, System: 32.6 ms]
  Range (min … max):    48.1 ms …  53.3 ms    53 runs
</pre>
</details>

<details>
<summary>With TCO (avg 55.8ms)</summary>
<pre>
$ hyperfine --warmup 100 'bin/lifp run examples/fibonacci.lifp'
Benchmark 1: bin/lifp run examples/fibonacci.lifp
  Time (mean ± σ):      55.8 ms ±   1.8 ms    [User: 8.6 ms, System: 41.9 ms]
  Range (min … max):    50.9 ms …  59.1 ms    48 runs
</pre>
</details>